### PR TITLE
fix(ci): push to GHCR on main branch before Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Push to GHCR (main branch)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker push "${{ steps.image-tag.outputs.full-image }}"
+
       - name: Push to GHCR (for PRs - adhoc testing)
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
## Summary

The push-dockerhub job pulls from GHCR, but the image was only pushed to GHCR for PR builds. This adds a step to push to GHCR on main branch so push-dockerhub can pull and re-tag for Docker Hub.

## Problem

On main branch:
1. Build job creates image locally
2. push-dockerhub job tries to `docker pull` from GHCR
3. Image doesn't exist in GHCR → **pull fails**

## Fix

Added "Push to GHCR (main branch)" step that runs before push-dockerhub job.

## Test plan

- [ ] Verify main branch build pushes to GHCR
- [ ] Verify push-dockerhub job successfully pulls and pushes to Docker Hub