### PR TITLE
fix(chart): improve deployment on clusters with tainted nodes

### DIFF
--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -65,6 +65,14 @@ spec:
         {{- toYaml .Values.controllerManager.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}
       terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.certmanager.enable (or .Values.webhook.enable .Values.metrics.enable) }}
       volumes:
         {{- if and .Values.metrics.enable .Values.certmanager.enable }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -49,6 +49,22 @@ controllerManager:
   serviceAccount:
     # Annotations to add to the service account (e.g., for EKS IAM roles)
     annotations: {}
+  # Tolerations for the controller manager pod
+  # Example: To run on GPU or specialized nodes:
+  # tolerations:
+  #   - key: "nvidia.com/gpu"
+  #     operator: "Exists"
+  #     effect: "NoSchedule"
+  #   - key: "workload-type"
+  #     operator: "Equal"
+  #     value: "session"
+  #     effect: "NoSchedule"
+  tolerations: []
+  # Node selector for the controller manager pod
+  # Example:
+  # nodeSelector:
+  #   kubernetes.io/os: linux
+  nodeSelector: {}
 
 # [RBAC]: To enable RBAC (Permissions) configurations
 rbac:


### PR DESCRIPTION
## Summary
- Remove kustomize-adopt hook that fails on tainted clusters
- Add configurable tolerations and nodeSelector for controller manager pod

## Test plan
- [ ] Deploy to cluster with GPU-tainted nodes
- [ ] Verify operator pod schedules successfully with appropriate tolerations
- [ ] Verify helm template renders correctly with/without tolerations