### PR TITLE
feat: add helm.sh/resource-policy: keep to all chart resources

### DIFF
--- a/dist/chart/templates/certmanager/certificate.yaml
+++ b/dist/chart/templates/certmanager/certificate.yaml
@@ -3,8 +3,10 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: selfsigned-issuer
@@ -17,8 +19,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   name: serving-cert
   namespace: {{ .Release.Namespace }}
   labels:
@@ -39,8 +43,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: metrics-certs

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -3,8 +3,10 @@ kind: Deployment
 metadata:
   name: team-operator-controller-manager
   namespace: {{ .Release.Namespace }}
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
     control-plane: controller-manager

--- a/dist/chart/templates/metrics/metrics-service.yaml
+++ b/dist/chart/templates/metrics/metrics-service.yaml
@@ -4,8 +4,10 @@ kind: Service
 metadata:
   name: team-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 spec:

--- a/dist/chart/templates/prometheus/monitor.yaml
+++ b/dist/chart/templates/prometheus/monitor.yaml
@@ -3,8 +3,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-controller-manager-metrics-monitor

--- a/dist/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-metrics-reader

--- a/dist/chart/templates/rbac/auth_proxy_role.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_role.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: proxy-role

--- a/dist/chart/templates/rbac/auth_proxy_role_binding.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_role_binding.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: proxy-rolebinding

--- a/dist/chart/templates/rbac/chronicle_editor_role.yaml
+++ b/dist/chart/templates/rbac/chronicle_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: chronicle-editor-role

--- a/dist/chart/templates/rbac/chronicle_viewer_role.yaml
+++ b/dist/chart/templates/rbac/chronicle_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: chronicle-viewer-role

--- a/dist/chart/templates/rbac/connect_editor_role.yaml
+++ b/dist/chart/templates/rbac/connect_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: connect-editor-role

--- a/dist/chart/templates/rbac/connect_viewer_role.yaml
+++ b/dist/chart/templates/rbac/connect_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: connect-viewer-role

--- a/dist/chart/templates/rbac/leader_election_role.yaml
+++ b/dist/chart/templates/rbac/leader_election_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/leader_election_role_binding.yaml
+++ b/dist/chart/templates/rbac/leader_election_role_binding.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/packagemanager_editor_role.yaml
+++ b/dist/chart/templates/rbac/packagemanager_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: packagemanager-editor-role

--- a/dist/chart/templates/rbac/packagemanager_viewer_role.yaml
+++ b/dist/chart/templates/rbac/packagemanager_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: packagemanager-viewer-role

--- a/dist/chart/templates/rbac/postgresdatabase_editor_role.yaml
+++ b/dist/chart/templates/rbac/postgresdatabase_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: postgresdatabase-editor-role

--- a/dist/chart/templates/rbac/postgresdatabase_viewer_role.yaml
+++ b/dist/chart/templates/rbac/postgresdatabase_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: postgresdatabase-viewer-role

--- a/dist/chart/templates/rbac/role.yaml
+++ b/dist/chart/templates/rbac/role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-manager-role
@@ -25,8 +27,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   name: team-operator-manager-role
   namespace: {{ .Values.watchNamespace }}
 rules:

--- a/dist/chart/templates/rbac/role_binding.yaml
+++ b/dist/chart/templates/rbac/role_binding.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-manager-rolebinding
@@ -20,8 +22,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   name: team-operator-manager-rolebinding
   namespace: {{ .Values.watchNamespace }}
   labels:

--- a/dist/chart/templates/rbac/service_account.yaml
+++ b/dist/chart/templates/rbac/service_account.yaml
@@ -4,13 +4,17 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+{{- if or .Values.resourcePolicy.keep (and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations) }}
   annotations:
+    {{- if .Values.resourcePolicy.keep }}
     helm.sh/resource-policy: keep
+    {{- end }}
     {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
     {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
     {{ $key }}: {{ $value }}
     {{- end }}
     {{- end }}
+{{- end }}
   name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/dist/chart/templates/rbac/site_editor_role.yaml
+++ b/dist/chart/templates/rbac/site_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: site-editor-role

--- a/dist/chart/templates/rbac/site_viewer_role.yaml
+++ b/dist/chart/templates/rbac/site_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: site-viewer-role

--- a/dist/chart/templates/rbac/workbench_editor_role.yaml
+++ b/dist/chart/templates/rbac/workbench_editor_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: workbench-editor-role

--- a/dist/chart/templates/rbac/workbench_viewer_role.yaml
+++ b/dist/chart/templates/rbac/workbench_viewer_role.yaml
@@ -3,8 +3,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+{{- if .Values.resourcePolicy.keep }}
   annotations:
     helm.sh/resource-policy: keep
+{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: workbench-viewer-role

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -81,6 +81,12 @@ crd:
   # the Helm release is uninstalled.
   keep: true
 
+# Resource policy for non-CRD resources (Deployment, RBAC, Services, etc.)
+# When enabled, adds helm.sh/resource-policy: keep annotation to prevent
+# deletion during helm uninstall
+resourcePolicy:
+  keep: true
+
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and ensure that the
 # ControllerManager argument "--metrics-bind-address=:8443" is removed.


### PR DESCRIPTION
## Summary

Adds `helm.sh/resource-policy: keep` annotation to all Kubernetes resources created by the Helm chart.

## Why

This enables safe migration from direct Pulumi Helm Release management to helm-controller (HelmChart CR) management. When Pulumi removes its Release resource, `helm uninstall` runs but resources with this annotation are preserved. The new HelmChart CR then adopts the existing resources via `helm upgrade`.

## Resources Protected

- Deployment (manager)
- ServiceAccount
- ClusterRoles (5), Roles (3)
- ClusterRoleBindings (3), RoleBindings (3)
- Service (metrics)
- ServiceMonitor
- Certificates (2), Issuer

**Note:** CRDs already have configurable protection via `crd.keep: true` (default).

## Related

- Plan: `thoughts/shared/plans/2026-01-20-team-operator-helm-controller-migration.md`
- Phase 1 of helm-controller migration