### PR TITLE
fix: add just format target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,6 +42,10 @@ build:
 mbuild:
   make build
 
+# Format code
+format:
+  go fmt ./...
+
 create-db-url-secret:
   #!/bin/bash
   set -xe


### PR DESCRIPTION
## Summary

Adds missing `just format` target referenced in documentation and Claude agent + settings.

#### Files using this target

- `CONTRIBUTING.md`
- `.claude/settings.json`
- `.claude/agents/team-operator.md`
