### PR TITLE
ci: use deploy key for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Switch from `GITHUB_TOKEN` to a deploy key for git operations in the release workflow.

## Why
This allows semantic-release to push release commits and tags to `main` while respecting branch protection rules. The deploy key (`semantic-release-team-operator`) is configured as a bypass actor in the new `main-protection` ruleset.

## Changes
- Replace `persist-credentials: false` with `ssh-key: ${{ secrets.DEPLOY_KEY }}` in checkout step

## Setup completed
- [x] Deploy key created and added to repo
- [x] Private key stored as `DEPLOY_KEY` secret
- [x] Ruleset created with deploy key bypass

## Test plan
- [ ] Merge this PR
- [ ] Verify next release workflow completes successfully