### PR TITLE
feat(workbench): add init container for load balancer config

### DIFF
--- a/internal/controller/core/workbench.go
+++ b/internal/controller/core/workbench.go
@@ -794,6 +794,7 @@ func (r *WorkbenchReconciler) ensureDeployedService(ctx context.Context, req ctr
 					ImagePullSecrets:             pullSecrets,
 					ServiceAccountName:           maybeServiceAccountName,
 					AutomountServiceAccountToken: ptr.To(true),
+					InitContainers:               r.buildWorkbenchInitContainers(w),
 					Containers: product.ConcatLists(
 						[]corev1.Container{
 							{
@@ -833,6 +834,7 @@ func (r *WorkbenchReconciler) ensureDeployedService(ctx context.Context, req ctr
 									workbenchVolumeFactory.VolumeMounts(),
 									workbenchSecretVolumeFactory.VolumeMounts(),
 									chronicleFactory.VolumeMounts(),
+									r.buildLoadBalancerVolumeMounts(w),
 								),
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -876,6 +878,7 @@ func (r *WorkbenchReconciler) ensureDeployedService(ctx context.Context, req ctr
 						workbenchVolumeFactory.Volumes(),
 						workbenchSecretVolumeFactory.Volumes(),
 						chronicleFactory.Volumes(),
+						r.buildLoadBalancerVolumes(w),
 					),
 				},
 			},
@@ -1026,4 +1029,79 @@ func (r *WorkbenchReconciler) cleanupDeployedService(ctx context.Context, req ct
 	l.Info("starting")
 
 	return nil
+}
+
+// loadBalancerVolumeName is the name of the emptyDir volume used for the load-balancer config
+const loadBalancerVolumeName = "load-balancer-config"
+
+// loadBalancerMountPath is where the load-balancer config is mounted in the container
+const loadBalancerMountPath = "/mnt/load-balancer"
+
+// isLoadBalancingEnabled returns true if load balancing is enabled for the workbench
+func (r *WorkbenchReconciler) isLoadBalancingEnabled(w *positcov1beta1.Workbench) bool {
+	return w.Spec.Config.RServer != nil && w.Spec.Config.RServer.LoadBalancingEnabled == 1
+}
+
+// buildWorkbenchInitContainers returns init containers for the workbench deployment.
+// When load balancing is enabled, it includes an init container that creates the
+// load-balancer configuration file with the pod's IP address.
+func (r *WorkbenchReconciler) buildWorkbenchInitContainers(w *positcov1beta1.Workbench) []corev1.Container {
+	if !r.isLoadBalancingEnabled(w) {
+		return nil
+	}
+
+	// The load-balancer file tells Workbench how to register with the load balancer.
+	// - delete-node-on-exit=1: Clean up this node's registration when the pod terminates
+	// - www-host-name: The IP address other nodes should use to contact this instance
+	//
+	// This matches the behavior of the RStudio Helm chart's prestart-workbench.bash script.
+	// See: https://github.com/rstudio/helm/blob/main/charts/rstudio-workbench/prestart-workbench.bash
+	initScript := `mkdir -p /mnt/load-balancer/rstudio && echo -e "delete-node-on-exit=1\nwww-host-name=$(hostname -i)" > /mnt/load-balancer/rstudio/load-balancer`
+
+	return []corev1.Container{
+		{
+			Name:    "load-balancer-init",
+			Image:   "busybox:1.36",
+			Command: []string{"/bin/sh", "-c"},
+			Args:    []string{initScript},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      loadBalancerVolumeName,
+					MountPath: loadBalancerMountPath,
+				},
+			},
+		},
+	}
+}
+
+// buildLoadBalancerVolumeMounts returns volume mounts for the load-balancer config.
+// Returns an empty slice if load balancing is not enabled.
+func (r *WorkbenchReconciler) buildLoadBalancerVolumeMounts(w *positcov1beta1.Workbench) []corev1.VolumeMount {
+	if !r.isLoadBalancingEnabled(w) {
+		return nil
+	}
+
+	return []corev1.VolumeMount{
+		{
+			Name:      loadBalancerVolumeName,
+			MountPath: loadBalancerMountPath,
+		},
+	}
+}
+
+// buildLoadBalancerVolumes returns the volumes needed for load-balancer configuration.
+// Returns an empty slice if load balancing is not enabled.
+func (r *WorkbenchReconciler) buildLoadBalancerVolumes(w *positcov1beta1.Workbench) []corev1.Volume {
+	if !r.isLoadBalancingEnabled(w) {
+		return nil
+	}
+
+	return []corev1.Volume{
+		{
+			Name: loadBalancerVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
 }

--- a/internal/controller/core/workbench_test.go
+++ b/internal/controller/core/workbench_test.go
@@ -262,3 +262,96 @@ func TestWorkbenchAuthSamlMissingMetadata(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "SAML authentication requires a metadata URL")
 }
+
+func TestWorkbenchLoadBalancingInitContainer(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "workbench-lb"
+
+	ctx, r, req, cli := initWorkbenchReconciler(t, ctx, ns, name)
+
+	wb := defineDefaultWorkbench(t, ns, name)
+	// Enable load balancing
+	wb.Spec.Config.RServer = &positcov1beta1.WorkbenchRServerConfig{
+		LoadBalancingEnabled: 1,
+	}
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Workbench{}, wb)
+	require.NoError(t, err)
+
+	wb = getWorkbench(t, cli, ns, name)
+
+	res, err := r.ReconcileWorkbench(ctx, req, wb)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	// Get the deployment and verify init container exists
+	deployment := getDeployment(t, cli, ns, name+"-workbench")
+
+	// Verify init container is present
+	require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1, "Should have one init container when load balancing is enabled")
+	initContainer := deployment.Spec.Template.Spec.InitContainers[0]
+	assert.Equal(t, "load-balancer-init", initContainer.Name)
+	assert.Equal(t, "busybox:1.36", initContainer.Image)
+	assert.Contains(t, initContainer.Args[0], "www-host-name=$(hostname -i)")
+	assert.Contains(t, initContainer.Args[0], "delete-node-on-exit=1")
+
+	// Verify volume mount on init container
+	require.Len(t, initContainer.VolumeMounts, 1, "Init container should have volume mount")
+	assert.Equal(t, "load-balancer-config", initContainer.VolumeMounts[0].Name)
+	assert.Equal(t, "/mnt/load-balancer", initContainer.VolumeMounts[0].MountPath)
+
+	// Verify the main container has the volume mount
+	mainContainer := deployment.Spec.Template.Spec.Containers[0]
+	var foundLbMount bool
+	for _, vm := range mainContainer.VolumeMounts {
+		if vm.Name == "load-balancer-config" {
+			foundLbMount = true
+			assert.Equal(t, "/mnt/load-balancer", vm.MountPath)
+			break
+		}
+	}
+	assert.True(t, foundLbMount, "Main container should have load-balancer-config volume mount")
+
+	// Verify the emptyDir volume is defined
+	var foundLbVolume bool
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		if v.Name == "load-balancer-config" {
+			foundLbVolume = true
+			assert.NotNil(t, v.EmptyDir, "load-balancer-config should be an emptyDir volume")
+			break
+		}
+	}
+	assert.True(t, foundLbVolume, "Deployment should have load-balancer-config volume")
+}
+
+func TestWorkbenchLoadBalancingDisabled(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "workbench-no-lb"
+
+	ctx, r, req, cli := initWorkbenchReconciler(t, ctx, ns, name)
+
+	wb := defineDefaultWorkbench(t, ns, name)
+	// Do NOT enable load balancing - leave RServer config nil
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Workbench{}, wb)
+	require.NoError(t, err)
+
+	wb = getWorkbench(t, cli, ns, name)
+
+	res, err := r.ReconcileWorkbench(ctx, req, wb)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	// Get the deployment and verify NO init container exists
+	deployment := getDeployment(t, cli, ns, name+"-workbench")
+
+	// Verify no init containers when load balancing is disabled
+	assert.Empty(t, deployment.Spec.Template.Spec.InitContainers, "Should have no init containers when load balancing is disabled")
+
+	// Verify no load-balancer-config volume exists
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		assert.NotEqual(t, "load-balancer-config", v.Name, "Should not have load-balancer-config volume when load balancing is disabled")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an init container to Workbench deployments that creates the `/mnt/load-balancer/rstudio/load-balancer` file when load balancing is enabled. This file is required for RStudio Workbench to properly coordinate between multiple replicas.

## Problem

When running Workbench with multiple replicas (`LoadBalancingEnabled=1`), each pod needs to register itself with the load balancer by creating a configuration file containing:
- Its IP address (`www-host-name`)
- A flag to clean up on exit (`delete-node-on-exit`)

Previously, this file was not being created, which prevented proper load balancing across replicas.

## Solution

Following the pattern from the [RStudio Helm chart's prestart-workbench.bash](https://github.com/rstudio/helm/blob/main/charts/rstudio-workbench/prestart-workbench.bash), we add:

1. **Init container** (`load-balancer-init`) - A lightweight busybox container that runs before the main Workbench container to create the load-balancer config file with the pod's IP address

2. **EmptyDir volume** (`load-balancer-config`) - Shared between init and main containers, mounted at `/mnt/load-balancer`

3. **Conditional activation** - All of this is only enabled when `LoadBalancingEnabled == 1` in the Workbench spec

## Changes

- `internal/controller/core/workbench.go`:
  - Added `isLoadBalancingEnabled()` helper
  - Added `buildWorkbenchInitContainers()` to create the init container
  - Added `buildLoadBalancerVolumeMounts()` and `buildLoadBalancerVolumes()` for volume management
  - Integrated init containers, volume mounts, and volumes into the deployment spec

- `internal/controller/core/workbench_test.go`:
  - Added `TestWorkbenchLoadBalancingInitContainer` - verifies init container, volumes, and mounts are created when load balancing is enabled
  - Added `TestWorkbenchLoadBalancingDisabled` - verifies no init container or volumes when load balancing is disabled

## How to verify

1. Deploy a Workbench with `LoadBalancingEnabled: 1` in the spec
2. Check that the pod has an init container named `load-balancer-init`
3. Verify the file `/mnt/load-balancer/rstudio/load-balancer` exists in the main container
4. File should contain `delete-node-on-exit=1` and `www-host-name=<pod-ip>`

## Test plan

- [x] Code compiles (`go build ./...`)
- [x] Unit tests pass
- [x] Manually tested on ganso01-staging with 5 replicas
  - Deployed adhoc image `ghcr.io/posit-dev/team-operator:adhoc-feat-workbench-load-balancer-init-v1.3.2-6-g4ac14b9`
  - Verified load-balancer file created correctly in each pod:
    ```
    delete-node-on-exit=1
    www-host-name=<pod-ip>
    ```
  - All 5 Workbench replicas running successfully (2/2 Ready)
  - Load balancing distributed events working across replicas