### PR TITLE
DRAFT: Changes based on `make helm-generate`

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -1,0 +1,90 @@
+name: Test Chart
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Prepare team-operator
+        run: |
+          go mod tidy
+          make docker-build IMG=team-operator:v0.1.0
+          kind load docker-image team-operator:v0.1.0
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Verify Helm installation
+        run: helm version
+
+      - name: Lint Helm Chart
+        run: |
+          helm lint ./dist/chart
+
+# TODO: Uncomment if cert-manager is enabled
+#      - name: Install cert-manager via Helm
+#        run: |
+#          helm repo add jetstack https://charts.jetstack.io
+#          helm repo update
+#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
+#
+#      - name: Wait for cert-manager to be ready
+#        run: |
+#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
+#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
+#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
+
+# TODO: Uncomment if Prometheus is enabled
+#      - name: Install Prometheus Operator CRDs
+#        run: |
+#          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#          helm repo update
+#          helm install prometheus-crds prometheus-community/prometheus-operator-crds
+#
+#      - name: Install Prometheus via Helm
+#        run: |
+#          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+#          helm repo update
+#          helm install prometheus prometheus-community/prometheus --namespace monitoring --create-namespace
+#
+#      - name: Wait for Prometheus to be ready
+#        run: |
+#          kubectl wait --namespace monitoring --for=condition=available --timeout=300s deployment/prometheus-server
+
+      - name: Install Helm chart for project
+        run: |
+          helm install my-release ./dist/chart --create-namespace --namespace team-operator-system
+
+      - name: Check Helm release status
+        run: |
+          helm status my-release --namespace team-operator-system
+
+# TODO: Uncomment if prometheus.enabled is set to true to confirm that the ServiceMonitor gets created
+#      - name: Check Presence of ServiceMonitor
+#        run: |
+#          kubectl wait --namespace team-operator-system --for=jsonpath='{.kind}'=ServiceMonitor servicemonitor/team-operator-controller-manager-metrics-monitor

--- a/dist/chart/templates/certmanager/certificate.yaml
+++ b/dist/chart/templates/certmanager/certificate.yaml
@@ -3,50 +3,22 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: selfsigned-issuer
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
-{{- if .Values.webhook.enable }}
----
-# Certificate for the webhook
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
-  name: serving-cert
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
-spec:
-  dnsNames:
-    - team-operator.{{ .Release.Namespace }}.svc
-    - team-operator.{{ .Release.Namespace }}.svc.cluster.local
-    - team-operator-webhook-service.{{ .Release.Namespace }}.svc
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: webhook-server-cert
-{{- end }}
 {{- if .Values.metrics.enable }}
 ---
 # Certificate for the metrics
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-{{- if .Values.resourcePolicy.keep }}
   annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: metrics-certs
@@ -55,7 +27,7 @@ spec:
   dnsNames:
     - team-operator.{{ .Release.Namespace }}.svc
     - team-operator.{{ .Release.Namespace }}.svc.cluster.local
-    - team-operator-controller-manager-metrics-service.{{ .Release.Namespace }}.svc
+    - team-operator-metrics-service.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/dist/chart/templates/crd/core.posit.team_chronicles.yaml
+++ b/dist/chart/templates/crd/core.posit.team_chronicles.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: chronicles.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: Chronicle

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: connects.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: Connect
@@ -511,932 +496,929 @@ spec:
                     description: PodConfig is the configuration for session pods
                     properties:
                       affinity:
-                        items:
-                          description: Affinity is a group of affinity scheduling
-                            rules.
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules
-                                for the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
                                   description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and adding
-                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: |-
-                                      An empty preferred scheduling term matches all objects with implicit weight 0
-                                      (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      weight:
-                                        description: Weight associated with matching
-                                          the corresponding nodeSelectorTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - preference
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    If the affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from its node.
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector
-                                        terms. The terms are ORed.
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
-                                        description: |-
-                                          A null or empty node selector term matches no objects. The requirements of
-                                          them are ANDed.
-                                          The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        type: object
-                                        x-kubernetes-map-type: atomic
+                                        type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
                                   required:
-                                  - nodeSelectorTerms
+                                  - topologyKey
                                   type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules
-                                (e.g. co-locate this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
                                                 description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
                                                       type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
                                                 type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
                                             type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: |-
-                                          weight associated with matching the corresponding podAffinityTerm,
-                                          in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    If the affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict the pod from its node.
-                                    When there are multiple elements, the lists of nodes corresponding to each
-                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: |-
-                                      Defines a set of pods (namely those matching the labelSelector
-                                      relative to the given namespace(s)) that this pod should be
-                                      co-located (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node whose value of
-                                      the label with key <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling
-                                rules (e.g. avoid putting this pod in the same node,
-                                zone, etc. as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the anti-affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and subtracting
-                                    "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
                                             type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: |-
-                                          weight associated with matching the corresponding podAffinityTerm,
-                                          in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
                                   description: |-
-                                    If the anti-affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the anti-affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict the pod from its node.
-                                    When there are multiple elements, the lists of nodes corresponding to each
-                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: |-
-                                      Defines a set of pods (namely those matching the labelSelector
-                                      relative to the given namespace(s)) that this pod should be
-                                      co-located (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node whose value of
-                                      the label with key <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
                                             description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
                                                   type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
                                             type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
                                         type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                          type: object
-                        type: array
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
                       annotations:
                         additionalProperties:
                           type: string

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: packagemanagers.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: PackageManager

--- a/dist/chart/templates/crd/core.posit.team_postgresdatabases.yaml
+++ b/dist/chart/templates/crd/core.posit.team_postgresdatabases.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: postgresdatabases.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: PostgresDatabase

--- a/dist/chart/templates/crd/core.posit.team_sites.yaml
+++ b/dist/chart/templates/crd/core.posit.team_sites.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: sites.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: Site
@@ -486,6 +471,11 @@ spec:
               flightdeck:
                 description: Flightdeck contains Flightdeck configuration
                 properties:
+                  enabled:
+                    description: |-
+                      Enabled controls whether Flightdeck is deployed. Defaults to true if not specified.
+                      Set to false to explicitly disable Flightdeck deployment.
+                    type: boolean
                   featureEnabler:
                     description: FeatureEnabler controls which features are enabled
                       in Flightdeck
@@ -500,7 +490,11 @@ spec:
                         type: boolean
                     type: object
                   image:
-                    description: Image is the container image for Flightdeck
+                    description: |-
+                      Image is the container image for Flightdeck.
+                      Can be a tag (e.g., "v1.2.3") which will be combined with the default registry,
+                      or a full image path (e.g., "my-registry.io/flightdeck:v1.0.0").
+                      Defaults to "docker.io/posit/ptd-flightdeck:latest" if not specified.
                     type: string
                   imagePullPolicy:
                     description: ImagePullPolicy controls when the kubelet pulls the
@@ -1328,6 +1322,46 @@ spec:
                     description: SessionInitContainerImageTag specifies the init container
                       image tag for Workbench sessions
                     type: string
+                  sessionTolerations:
+                    description: SessionTolerations are tolerations applied only to
+                      session pods (not the main workbench server)
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   snowflake:
                     properties:
                       accountId:

--- a/dist/chart/templates/crd/core.posit.team_workbenches.yaml
+++ b/dist/chart/templates/crd/core.posit.team_workbenches.yaml
@@ -6,27 +6,12 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.certmanager.enable }}
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/serving-cert"
-    {{- end }}
     {{- if .Values.crd.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.17.0
   name: workbenches.core.posit.team
 spec:
-  {{- if .Values.webhook.enable }}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: {{ .Release.Namespace }}
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  {{- end }}
   group: core.posit.team
   names:
     kind: Workbench
@@ -751,932 +736,929 @@ spec:
                     description: PodConfig is the configuration for session pods
                     properties:
                       affinity:
-                        items:
-                          description: Affinity is a group of affinity scheduling
-                            rules.
-                          properties:
-                            nodeAffinity:
-                              description: Describes node affinity scheduling rules
-                                for the pod.
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
                                   description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and adding
-                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: |-
-                                      An empty preferred scheduling term matches all objects with implicit weight 0
-                                      (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                                    properties:
-                                      preference:
-                                        description: A node selector term, associated
-                                          with the corresponding weight.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      weight:
-                                        description: Weight associated with matching
-                                          the corresponding nodeSelectorTerm, in the
-                                          range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - preference
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    If the affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to an update), the system
-                                    may or may not try to eventually evict the pod from its node.
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
-                                    nodeSelectorTerms:
-                                      description: Required. A list of node selector
-                                        terms. The terms are ORed.
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
                                       items:
-                                        description: |-
-                                          A null or empty node selector term matches no objects. The requirements of
-                                          them are ANDed.
-                                          The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                        properties:
-                                          matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
-                                            items:
-                                              description: |-
-                                                A node selector requirement is a selector that contains values, a key, and an operator
-                                                that relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: The label key that
-                                                    the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    Represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    An array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. If the operator is Gt or Lt, the values
-                                                    array must have a single element, which will be interpreted as an integer.
-                                                    This array is replaced during a strategic merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                        type: object
-                                        x-kubernetes-map-type: atomic
+                                        type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
                                   required:
-                                  - nodeSelectorTerms
+                                  - topologyKey
                                   type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                            podAffinity:
-                              description: Describes pod affinity scheduling rules
-                                (e.g. co-locate this pod in the same node, zone, etc.
-                                as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and adding
-                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
                                                 description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
                                                       type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
                                                 type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
                                             type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: |-
-                                          weight associated with matching the corresponding podAffinityTerm,
-                                          in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    If the affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict the pod from its node.
-                                    When there are multiple elements, the lists of nodes corresponding to each
-                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: |-
-                                      Defines a set of pods (namely those matching the labelSelector
-                                      relative to the given namespace(s)) that this pod should be
-                                      co-located (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node whose value of
-                                      the label with key <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                            podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling
-                                rules (e.g. avoid putting this pod in the same node,
-                                zone, etc. as some other pod(s)).
-                              properties:
-                                preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: |-
-                                    The scheduler will prefer to schedule pods to nodes that satisfy
-                                    the anti-affinity expressions specified by this field, but it may choose
-                                    a node that violates one or more of the expressions. The node that is
-                                    most preferred is the one with the greatest sum of weights, i.e.
-                                    for each node that meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                    compute a sum by iterating through the elements of this field and subtracting
-                                    "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                    node(s) with the highest sum are the most preferred.
-                                  items:
-                                    description: The weights of all of the matched
-                                      WeightedPodAffinityTerm fields are added per-node
-                                      to find the most preferred node(s)
-                                    properties:
-                                      podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
-                                        properties:
-                                          labelSelector:
-                                            description: |-
-                                              A label query over a set of resources, in this case pods.
-                                              If it's null, this PodAffinityTerm matches with no Pods.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          matchLabelKeys:
-                                            description: |-
-                                              MatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          mismatchLabelKeys:
-                                            description: |-
-                                              MismatchLabelKeys is a set of pod label keys to select which pods will
-                                              be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                              to select the group of existing pods which pods will be taken into consideration
-                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                              pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          namespaceSelector:
-                                            description: |-
-                                              A label query over the set of namespaces that the term applies to.
-                                              The term is applied to the union of the namespaces selected by this field
-                                              and the ones listed in the namespaces field.
-                                              null selector and null or empty namespaces list means "this pod's namespace".
-                                              An empty selector ({}) matches all namespaces.
-                                            properties:
-                                              matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
-                                                items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
-                                                  properties:
-                                                    key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
-                                                      type: string
-                                                    operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                      type: string
-                                                    values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                      x-kubernetes-list-type: atomic
-                                                  required:
-                                                  - key
-                                                  - operator
-                                                  type: object
-                                                type: array
-                                                x-kubernetes-list-type: atomic
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                                type: object
-                                            type: object
-                                            x-kubernetes-map-type: atomic
-                                          namespaces:
-                                            description: |-
-                                              namespaces specifies a static list of namespace names that the term applies to.
-                                              The term is applied to the union of the namespaces listed in this field
-                                              and the ones selected by namespaceSelector.
-                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                            items:
-                                              type: string
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          topologyKey:
-                                            description: |-
-                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                              whose value of the label with key topologyKey matches that of any node on which any of the
-                                              selected pods is running.
-                                              Empty topologyKey is not allowed.
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
                                             type: string
-                                        required:
-                                        - topologyKey
-                                        type: object
-                                      weight:
-                                        description: |-
-                                          weight associated with matching the corresponding podAffinityTerm,
-                                          in the range 1-100.
-                                        format: int32
-                                        type: integer
-                                    required:
-                                    - podAffinityTerm
-                                    - weight
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                                requiredDuringSchedulingIgnoredDuringExecution:
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
                                   description: |-
-                                    If the anti-affinity requirements specified by this field are not met at
-                                    scheduling time, the pod will not be scheduled onto the node.
-                                    If the anti-affinity requirements specified by this field cease to be met
-                                    at some point during pod execution (e.g. due to a pod label update), the
-                                    system may or may not try to eventually evict the pod from its node.
-                                    When there are multiple elements, the lists of nodes corresponding to each
-                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                                  items:
-                                    description: |-
-                                      Defines a set of pods (namely those matching the labelSelector
-                                      relative to the given namespace(s)) that this pod should be
-                                      co-located (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node whose value of
-                                      the label with key <topologyKey> matches that of any node on which
-                                      a pod of the set of pods is running
-                                    properties:
-                                      labelSelector:
-                                        description: |-
-                                          A label query over a set of resources, in this case pods.
-                                          If it's null, this PodAffinityTerm matches with no Pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
                                             description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      matchLabelKeys:
-                                        description: |-
-                                          MatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
-                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      mismatchLabelKeys:
-                                        description: |-
-                                          MismatchLabelKeys is a set of pod label keys to select which pods will
-                                          be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
-                                          to select the group of existing pods which pods will be taken into consideration
-                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                          pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
-                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      namespaceSelector:
-                                        description: |-
-                                          A label query over the set of namespaces that the term applies to.
-                                          The term is applied to the union of the namespaces selected by this field
-                                          and the ones listed in the namespaces field.
-                                          null selector and null or empty namespaces list means "this pod's namespace".
-                                          An empty selector ({}) matches all namespaces.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: |-
-                                                A label selector requirement is a selector that contains values, a key, and an operator that
-                                                relates the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
                                                   type: string
-                                                operator:
-                                                  description: |-
-                                                    operator represents a key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: |-
-                                                    values is an array of string values. If the operator is In or NotIn,
-                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty. This array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                                  x-kubernetes-list-type: atomic
-                                              required:
-                                              - key
-                                              - operator
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-type: atomic
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: |-
-                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
                                             type: object
-                                        type: object
-                                        x-kubernetes-map-type: atomic
-                                      namespaces:
-                                        description: |-
-                                          namespaces specifies a static list of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces listed in this field
-                                          and the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                        items:
-                                          type: string
-                                        type: array
-                                        x-kubernetes-list-type: atomic
-                                      topologyKey:
-                                        description: |-
-                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                          whose value of the label with key topologyKey matches that of any node on which any of the
-                                          selected pods is running.
-                                          Empty topologyKey is not allowed.
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
                                         type: string
-                                    required:
-                                    - topologyKey
-                                    type: object
-                                  type: array
-                                  x-kubernetes-list-type: atomic
-                              type: object
-                          type: object
-                        type: array
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
                       annotations:
                         additionalProperties:
                           type: string

--- a/dist/chart/templates/metrics/metrics-service.yaml
+++ b/dist/chart/templates/metrics/metrics-service.yaml
@@ -2,14 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.controllerManager.serviceAccountName }}-metrics-service
+  name: team-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/dist/chart/templates/prometheus/monitor.yaml
+++ b/dist/chart/templates/prometheus/monitor.yaml
@@ -3,12 +3,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
   name: team-operator-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/dist/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -2,10 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-metrics-reader

--- a/dist/chart/templates/rbac/auth_proxy_role.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_role.yaml
@@ -2,10 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: proxy-role

--- a/dist/chart/templates/rbac/auth_proxy_role_binding.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_role_binding.yaml
@@ -2,10 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: proxy-rolebinding

--- a/dist/chart/templates/rbac/auth_proxy_service.yaml
+++ b/dist/chart/templates/rbac/auth_proxy_service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: {{ .Values.controllerManager.serviceAccountName }}-metrics-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+{{- end -}}

--- a/dist/chart/templates/rbac/chronicle_editor_role.yaml
+++ b/dist/chart/templates/rbac/chronicle_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: chronicle-editor-role

--- a/dist/chart/templates/rbac/chronicle_viewer_role.yaml
+++ b/dist/chart/templates/rbac/chronicle_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: chronicle-viewer-role

--- a/dist/chart/templates/rbac/connect_editor_role.yaml
+++ b/dist/chart/templates/rbac/connect_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: connect-editor-role

--- a/dist/chart/templates/rbac/connect_viewer_role.yaml
+++ b/dist/chart/templates/rbac/connect_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: connect-viewer-role

--- a/dist/chart/templates/rbac/leader_election_role.yaml
+++ b/dist/chart/templates/rbac/leader_election_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/leader_election_role_binding.yaml
+++ b/dist/chart/templates/rbac/leader_election_role_binding.yaml
@@ -2,10 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}

--- a/dist/chart/templates/rbac/packagemanager_editor_role.yaml
+++ b/dist/chart/templates/rbac/packagemanager_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: packagemanager-editor-role

--- a/dist/chart/templates/rbac/packagemanager_viewer_role.yaml
+++ b/dist/chart/templates/rbac/packagemanager_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: packagemanager-viewer-role

--- a/dist/chart/templates/rbac/postgresdatabase_editor_role.yaml
+++ b/dist/chart/templates/rbac/postgresdatabase_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: postgresdatabase-editor-role

--- a/dist/chart/templates/rbac/postgresdatabase_viewer_role.yaml
+++ b/dist/chart/templates/rbac/postgresdatabase_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: postgresdatabase-viewer-role

--- a/dist/chart/templates/rbac/role.yaml
+++ b/dist/chart/templates/rbac/role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-manager-role
@@ -27,12 +23,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   name: team-operator-manager-role
-  namespace: {{ .Values.watchNamespace }}
+  namespace: posit-team
 rules:
 - apiGroups:
   - ""

--- a/dist/chart/templates/rbac/role_binding.yaml
+++ b/dist/chart/templates/rbac/role_binding.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: team-operator-manager-rolebinding
@@ -22,14 +18,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   name: team-operator-manager-rolebinding
-  namespace: {{ .Values.watchNamespace }}
-  labels:
-    {{- include "chart.labels" . | nindent 4 }}
+  # NOTE: The namespace will be set via kustomize to `posit-team-system` but we need this
+  # role binding to be in the `posit-team` "watch namespace". I haven't figured out how to
+  # do this directly in the kustomize layer, but we have an opportunity to patch arbitrary
+  # things in pulumi, so that's where this will get patched before apply. ~ @meatballhat
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/dist/chart/templates/rbac/service_account.yaml
+++ b/dist/chart/templates/rbac/service_account.yaml
@@ -4,17 +4,12 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-{{- if or .Values.resourcePolicy.keep (and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations) }}
+  {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
   annotations:
-    {{- if .Values.resourcePolicy.keep }}
-    helm.sh/resource-policy: keep
-    {{- end }}
-    {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
     {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
     {{ $key }}: {{ $value }}
     {{- end }}
-    {{- end }}
-{{- end }}
+  {{- end }}
   name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/dist/chart/templates/rbac/site_editor_role.yaml
+++ b/dist/chart/templates/rbac/site_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: site-editor-role

--- a/dist/chart/templates/rbac/site_viewer_role.yaml
+++ b/dist/chart/templates/rbac/site_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: site-viewer-role

--- a/dist/chart/templates/rbac/workbench_editor_role.yaml
+++ b/dist/chart/templates/rbac/workbench_editor_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: workbench-editor-role

--- a/dist/chart/templates/rbac/workbench_viewer_role.yaml
+++ b/dist/chart/templates/rbac/workbench_viewer_role.yaml
@@ -3,10 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-{{- if .Values.resourcePolicy.keep }}
-  annotations:
-    helm.sh/resource-policy: keep
-{{- end }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
   name: workbench-viewer-role


### PR DESCRIPTION
I noticed some fields missing from the Site CRD (specifically, `sessionTolerations` in this instance) while trying to update an existing environment. Particularly, `config/crd/bases` is out-of-sync with `dist/chart/templates/crd`, and it appears that there is drift in general between the Helm chart CRDs and the underlying base CRDs. From what I can gather, we use `make helm-generate` to keep these in sync, but it isn't reflected in any of the developer workflows or CI.

After running `make helm-generate`, there is a very large diff (captured in this draft PR) -- and it also appears to want to setup additional GH action workflows, etc. Is `make helm-generate` supposed to be just a one-time thing?  How should we be keeping the Helm CRDs and the base CRDs in sync otherwise?