### PR TITLE
feat: dispatch version update to PTD on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,8 @@ jobs:
       - name: Dispatch version update to PTD
         if: steps.get-tag.outputs.tag != ''
         env:
-          PTD_REPO_TOKEN: ${{ secrets.PTD_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.PTD_REPO_TOKEN }}
         run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $PTD_REPO_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/posit-dev/ptd/dispatches \
-            -d '{"event_type":"team-operator-release","client_payload":{"version":"${{ steps.get-tag.outputs.tag }}"}}'
+          gh workflow run update-team-operator-version.yml \
+            --repo posit-dev/ptd \
+            --field version=${{ steps.get-tag.outputs.tag }}


### PR DESCRIPTION
## Summary
- Adds a `notify-ptd` job to the release workflow
- After `package-helm` succeeds, sends a `repository_dispatch` event to `posit-dev/ptd`
- PTD receives the event and creates a PR to update the default team-operator chart version

## Setup Required
Add `PTD_REPO_TOKEN` secret to this repo with a PAT that has `repo` scope for `posit-dev/ptd`.

## Related
- PTD PR: https://github.com/posit-dev/ptd/pull/102

## Test plan
- [ ] Merge PTD workflow first
- [ ] Add `PTD_REPO_TOKEN` secret
- [ ] Test with manual `workflow_dispatch` or wait for next release