### PR TITLE
fix(rbac): add namespace to RoleBinding for watch namespace permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,8 @@ helm-generate: manifests kubebuilder ## Regenerate Helm chart from kustomize
 	# Fix generated files that kubebuilder doesn't template correctly
 	$(SED) -i 's/team-operator-metrics-service/{{ .Values.controllerManager.serviceAccountName }}-metrics-service/g' dist/chart/templates/certmanager/certificate.yaml
 	$(SED) -i 's/team-operator-controller-manager-metrics-service/{{ .Values.controllerManager.serviceAccountName }}-metrics-service/g' dist/chart/templates/metrics/metrics-service.yaml
+	# Fix RoleBinding namespace to use watchNamespace value
+	$(SED) -i '/kind: RoleBinding/,/roleRef:/{s/namespace: posit-team/namespace: {{ .Values.watchNamespace }}/}' dist/chart/templates/rbac/role_binding.yaml
 	# Remove kubebuilder-generated test workflow - we use our own CI workflows
 	rm -f .github/workflows/test-chart.yml
 

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -30,10 +30,7 @@ metadata:
     app.kubernetes.io/part-of: team-operator
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
-  # NOTE: The namespace will be set via kustomize to `posit-team-system` but we need this
-  # role binding to be in the `posit-team` "watch namespace". I haven't figured out how to
-  # do this directly in the kustomize layer, but we have an opportunity to patch arbitrary
-  # things in pulumi, so that's where this will get patched before apply. ~ @meatballhat
+  namespace: posit-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/dist/chart/templates/rbac/role_binding.yaml
+++ b/dist/chart/templates/rbac/role_binding.yaml
@@ -19,10 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: team-operator-manager-rolebinding
-  # NOTE: The namespace will be set via kustomize to `posit-team-system` but we need this
-  # role binding to be in the `posit-team` "watch namespace". I haven't figured out how to
-  # do this directly in the kustomize layer, but we have an opportunity to patch arbitrary
-  # things in pulumi, so that's where this will get patched before apply. ~ @meatballhat
+  namespace: {{ .Values.watchNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
## Summary

- Fixes RBAC permission errors where the operator couldn't watch resources in the `posit-team` namespace
- The RoleBinding was missing a `namespace` field, causing it to be created in `posit-team-system` instead of `posit-team`

## Changes

- Add `namespace: posit-team` to kustomize source (`config/rbac/role_binding.yaml`)
- Add Makefile post-processing to template `{{ .Values.watchNamespace }}` in Helm chart (matching existing pattern for other fixes)

## Test plan

- [ ] Deploy to test cluster and verify operator starts without RBAC errors
- [ ] Verify RoleBinding is created in `posit-team` namespace