### PR TITLE
feat: Add NetworkPolicy for flightdeck component

### DIFF
--- a/internal/controller/core/site_controller_networkpolicies.go
+++ b/internal/controller/core/site_controller_networkpolicies.go
@@ -78,6 +78,11 @@ func (r *SiteReconciler) reconcileNetworkPolicies(ctx context.Context, req ctrl.
 		return err
 	}
 
+	if err := r.reconcileFlightdeckNetworkPolicy(ctx, req.Namespace, l, site); err != nil {
+		l.Error(err, "error ensuring flightdeck network policy")
+		return err
+	}
+
 	return nil
 }
 
@@ -90,6 +95,7 @@ func (r *SiteReconciler) cleanupNetworkPolicies(ctx context.Context, req ctrl.Re
 		"chronicle",
 		"connect",
 		"connect-session",
+		"flightdeck",
 		"home",
 		"keycloak",
 		"packagemanager",
@@ -715,6 +721,60 @@ func (r *SiteReconciler) reconcileWorkbenchSessionNetworkPolicy(ctx context.Cont
 					Ports: []networkingv1.NetworkPolicyPort{
 						internal.DefaultPortWorkbenchSessionHTTP.NetworkPolicyPort(),
 						internal.DefaultPortWorkbenchSessionProxy.NetworkPolicyPort(),
+					},
+				},
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+func (r *SiteReconciler) reconcileFlightdeckNetworkPolicy(ctx context.Context, namespace string, l logr.Logger, site *v1beta1.Site) error {
+	policyName := site.Name + "-flightdeck"
+
+	policy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: namespace,
+		},
+	}
+	_, err := internal.CreateOrUpdateResource(ctx, r.Client, r.Scheme, l, policy, site, func() error {
+		policy.Labels = site.KubernetesLabels()
+		policy.Spec = networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					v1beta1.SiteLabelKey:               site.Name,
+					v1beta1.KubernetesInstanceLabelKey: policyName,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+				networkingv1.PolicyTypeIngress,
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									v1beta1.KubernetesMetadataNameKey: "traefik",
+								},
+							},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									v1beta1.KubernetesMetadataNameKey: grafanaAlloyNamespace,
+								},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						internal.DefaultPortFlightdeckHTTP.NetworkPolicyPort(),
 					},
 				},
 			},

--- a/internal/tcpport.go
+++ b/internal/tcpport.go
@@ -14,6 +14,7 @@ const (
 	DefaultPortChronicleHTTP         TCPPort = 5252
 	DefaultPortChronicleMetrics      TCPPort = 3030
 	DefaultPortConnectHTTP           TCPPort = 3939
+	DefaultPortFlightdeckHTTP        TCPPort = 8080
 	DefaultPortConnectMetrics        TCPPort = 3232
 	DefaultPortConnectSession        TCPPort = 50734
 	DefaultPortHomeHTTP              TCPPort = 8080


### PR DESCRIPTION
## Summary
Add flightdeck to the list of components that get NetworkPolicies created by the site controller.

Previously, flightdeck was the only component without a NetworkPolicy, which caused issues in environments with default-deny network policies.

## Changes
- Add `DefaultPortFlightdeckHTTP` constant (8080)
- Add `reconcileFlightdeckNetworkPolicy()` function
- Add flightdeck to cleanup function
- Policy allows ingress from traefik/alloy on port 8080, egress to all

## Test plan
- [ ] Deploy to test cluster
- [ ] Verify NetworkPolicy is created for flightdeck
- [ ] Verify flightdeck UI accessible through traefik