### PR TITLE
fix: only tag docker release after corresponding image is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,14 +106,20 @@ jobs:
         run: |
           echo "Waiting for build workflow to push Docker image..."
           # Find the build workflow run for this exact commit (not just the latest run,
-          # which could belong to a different merge if two PRs land in quick succession)
-          RUN_ID=$(gh run list \
-            --workflow="build.yml" \
-            --branch=main \
-            --commit="${{ github.sha }}" \
-            --limit=1 \
-            --json databaseId \
-            --jq '.[0].databaseId')
+          # which could belong to a different merge if two PRs land in quick succession).
+          # Retry because the build.yml run may not be registered yet when this executes.
+          for i in $(seq 1 5); do
+            RUN_ID=$(gh run list \
+              --workflow="build.yml" \
+              --branch=main \
+              --commit="${{ github.sha }}" \
+              --limit=1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+            [ -n "$RUN_ID" ] && break
+            echo "Build run not found yet, retrying in 10s..."
+            sleep 10
+          done
 
           if [ -z "$RUN_ID" ]; then
             echo "::error::Could not find build workflow run for commit ${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,11 @@ on:
     branches:
       - main
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
       - 'docs/**'
       - '.github/workflows/**'
+      - '.claude/**'
+      - 'LICENSE'
   workflow_dispatch:
 
 permissions:
@@ -68,6 +70,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+  # Tags the Docker Hub `:latest` image with the release version (e.g., :v1.22.0).
+  # Both release.yml and build.yml trigger on push to main. build.yml takes ~10 min
+  # to build and push `:latest`, while this workflow's semantic-release + tag job
+  # completes in under a minute. Without the wait step below, this job would pull a
+  # stale `:latest` from the *previous* release and tag it with the *new* version.
   tag-docker-release:
     needs: release
     runs-on: ubuntu-latest
@@ -87,6 +94,35 @@ jobs:
           git fetch --tags
           TAG=$(git tag --sort=-version:refname | head -1 || echo "")
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      # On push: wait for build.yml to finish so :latest has the current commit's code.
+      # On workflow_dispatch: skip the wait — dispatch is used for manual recovery when
+      # :latest is already correct but the version tag needs to be re-applied.
+      - name: Wait for build workflow to push Docker image
+        if: steps.get-tag.outputs.tag != '' && github.event_name == 'push'
+        timeout-minutes: 15
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Waiting for build workflow to push Docker image..."
+          # Find the build workflow run for this exact commit (not just the latest run,
+          # which could belong to a different merge if two PRs land in quick succession)
+          RUN_ID=$(gh run list \
+            --workflow="build.yml" \
+            --branch=main \
+            --commit="${{ github.sha }}" \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Could not find build workflow run for commit ${{ github.sha }}"
+            exit 1
+          fi
+
+          echo "Waiting for build workflow run ${RUN_ID} to complete..."
+          gh run watch "$RUN_ID" --exit-status
+          echo "Build workflow completed successfully."
 
       - name: Login to Docker Hub
         if: steps.get-tag.outputs.tag != ''


### PR DESCRIPTION
# Description

Both `release.yml` and `build.yml` trigger on push to main. `build.yml` takes ~10 min to build and push `:latest`, while `tag-docker-release` completes in ~15 seconds. This meant every release tag was consistently one version behind.


- Fix race condition where `tag-docker-release` pulls `:latest` before `build.yml` has finished pushing it, causing every versioned Docker tag to point to the **previous** release's image
- Add a wait step that uses `gh run watch` to block until `build.yml` completes for the exact commit SHA before pulling and re-tagging `:latest`
- Skip the wait on `workflow_dispatch` so manual re-tagging (recovery) still works immediately
- Align `paths-ignore` between `release.yml` and `build.yml` to prevent release triggering without a corresponding build
- Add 15-minute timeout on the wait step


## Category of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Build: a code change that affects the build system or external dependencies
- [ ] Performance: a code change that improves performance
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature
- [ ] Documentation: documentation changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have run `just test` and all tests pass
- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about
