### PR TITLE
fix: bump controller manager memory limit from 128Mi to 192Mi

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 192Mi
           requests:
             cpu: 5m
             memory: 64Mi

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -44,7 +44,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 192Mi
+            memory: 128Mi
           requests:
             cpu: 5m
             memory: 64Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -94,7 +94,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 192Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/dist/chart/README.md
+++ b/dist/chart/README.md
@@ -129,7 +129,7 @@ helm uninstall team-operator --namespace posit-team-system
 | `controllerManager.container.args` | Container arguments | See values.yaml | No |
 | `controllerManager.container.env` | Environment variables | See values.yaml | No |
 | `controllerManager.container.resources.limits.cpu` | CPU limit | `500m` | No |
-| `controllerManager.container.resources.limits.memory` | Memory limit | `128Mi` | No |
+| `controllerManager.container.resources.limits.memory` | Memory limit | `192Mi` | No |
 | `controllerManager.container.resources.requests.cpu` | CPU request | `10m` | No |
 | `controllerManager.container.resources.requests.memory` | Memory request | `64Mi` | No |
 

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -26,7 +26,7 @@ controllerManager:
     resources:
       limits:
         cpu: 500m
-        memory: 128Mi
+        memory: 192Mi
       requests:
         cpu: 10m
         memory: 64Mi


### PR DESCRIPTION
## Description

The controller manager pod was OOMKilling in production. This increases the default memory limit from 128Mi to 192Mi to provide additional headroom.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run `just test` and all tests pass
- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about