### PR TITLE
fix: prevent status-patch reconcile storm in Site and child controllers

### DIFF
--- a/internal/controller/core/chronicle_controller.go
+++ b/internal/controller/core/chronicle_controller.go
@@ -19,8 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	positcov1beta1 "github.com/posit-dev/team-operator/api/core/v1beta1"
 )
@@ -90,7 +92,7 @@ func (r *ChronicleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *ChronicleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.Chronicle{}).
+		For(&positcov1beta1.Chronicle{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&v1.StatefulSet{}).
 		Complete(r)
 }

--- a/internal/controller/core/connect_controller.go
+++ b/internal/controller/core/connect_controller.go
@@ -12,8 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	positcov1beta1 "github.com/posit-dev/team-operator/api/core/v1beta1"
 )
@@ -93,7 +95,7 @@ func (r *ConnectReconciler) GetLogger(ctx context.Context) logr.Logger {
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConnectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.Connect{}).
+		For(&positcov1beta1.Connect{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }

--- a/internal/controller/core/flightdeck_controller.go
+++ b/internal/controller/core/flightdeck_controller.go
@@ -21,7 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // FlightdeckReconciler reconciles a Flightdeck object
@@ -465,7 +467,7 @@ func (r *FlightdeckReconciler) GetLogger(ctx context.Context) logr.Logger {
 // SetupWithManager sets up the controller with the Manager.
 func (r *FlightdeckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.Flightdeck{}).
+		For(&positcov1beta1.Flightdeck{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("flightdeck").
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).

--- a/internal/controller/core/packagemanager_controller.go
+++ b/internal/controller/core/packagemanager_controller.go
@@ -12,8 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	positcov1beta1 "github.com/posit-dev/team-operator/api/core/v1beta1"
 )
@@ -81,7 +83,7 @@ func (r *PackageManagerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 // SetupWithManager sets up the controller with the Manager.
 func (r *PackageManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.PackageManager{}).
+		For(&positcov1beta1.PackageManager{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }

--- a/internal/controller/core/site_controller.go
+++ b/internal/controller/core/site_controller.go
@@ -21,8 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // checkBool dereferences a bool pointer, returning defaultVal if nil.
@@ -705,7 +707,7 @@ func (r *SiteReconciler) cleanupResources(ctx context.Context, req ctrl.Request)
 // SetupWithManager sets up the controller with the Manager.
 func (r *SiteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.Site{}).
+		For(&positcov1beta1.Site{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&positcov1beta1.Connect{}).
 		Owns(&positcov1beta1.Workbench{}).
 		Owns(&positcov1beta1.PackageManager{}).

--- a/internal/controller/core/workbench_controller.go
+++ b/internal/controller/core/workbench_controller.go
@@ -12,8 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	positcov1beta1 "github.com/posit-dev/team-operator/api/core/v1beta1"
 )
@@ -88,7 +90,7 @@ func (r *WorkbenchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkbenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&positcov1beta1.Workbench{}).
+		For(&positcov1beta1.Workbench{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary

- The status improvement in commit eb3f7b0 introduced `SetProgressing(true)` at the start of every reconcile for Site and all child controllers, followed by `SetProgressing(false)` at the end. This flips `LastTransitionTime` on every cycle, making every status patch non-empty.
- Without a generation predicate on `For()`, those status patches fire watch events that re-enqueue the reconciler — a self-perpetuating loop.
- On a staging cluster this drove the Site controller to ~180 reconciles/second across all sites, causing elevated network packet rates on the controller node.
- `PostgresDatabaseReconciler` already had `GenerationChangedPredicate` applied correctly; this PR applies the same fix to the remaining six controllers.

## What changed

Added `builder.WithPredicates(predicate.GenerationChangedPredicate{})` to the `For()` call in `SetupWithManager` for: `SiteReconciler`, `ConnectReconciler`, `WorkbenchReconciler`, `PackageManagerReconciler`, `ChronicleReconciler`, `FlightdeckReconciler`.

`Owns()` watches are intentionally left without the predicate so child status changes continue to propagate up to `aggregateChildStatus`.

## Test plan

- [ ] Deploy to affected staging cluster and confirm reconcile rate returns to normal (~1/15s baseline seen on healthy clusters)
- [ ] Verify Site status conditions still update correctly when child components transition to Ready
- [ ] Existing unit tests pass (envtest-based tests require kubebuilder binaries not available locally)
