### PR TITLE
fix: add /mnt/load-balancer to XDG_CONFIG_DIRS so Workbench reads load-balancer config

### DIFF
--- a/api/core/v1beta1/workbench_types.go
+++ b/api/core/v1beta1/workbench_types.go
@@ -494,7 +494,7 @@ func (w *Workbench) InitializeNonRootSupervisorConfig(ctx context.Context, confi
 			StdOutLogFileMaxBytes: 0,
 			StdErrLogFile:         "/dev/stderr",
 			StdErrLogFileMaxBytes: 0,
-			Environment:           `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer"`,
+			Environment:           `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer/rstudio"`,
 		},
 	}
 	return nil
@@ -693,7 +693,7 @@ func (w *Workbench) CreateVolumeFactory(cfg *WorkbenchConfig) *product.VolumeFac
 			Env: []corev1.EnvVar{
 				{
 					Name:  "XDG_CONFIG_DIRS",
-					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer",
+					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer/rstudio",
 				},
 				{
 					Name: "RSW_TESTUSER_PASSWD",

--- a/api/core/v1beta1/workbench_types.go
+++ b/api/core/v1beta1/workbench_types.go
@@ -494,7 +494,7 @@ func (w *Workbench) InitializeNonRootSupervisorConfig(ctx context.Context, confi
 			StdOutLogFileMaxBytes: 0,
 			StdErrLogFile:         "/dev/stderr",
 			StdErrLogFileMaxBytes: 0,
-			Environment:           `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session"`,
+			Environment:           `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer"`,
 		},
 	}
 	return nil
@@ -693,7 +693,7 @@ func (w *Workbench) CreateVolumeFactory(cfg *WorkbenchConfig) *product.VolumeFac
 			Env: []corev1.EnvVar{
 				{
 					Name:  "XDG_CONFIG_DIRS",
-					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session",
+					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer",
 				},
 				{
 					Name: "RSW_TESTUSER_PASSWD",


### PR DESCRIPTION
## Description

The init container writes `/mnt/load-balancer/rstudio/load-balancer` with load-balancer settings (`delete-node-on-exit=1`, `www-host-name=<pod-ip>`). The volume is mounted at `/mnt/load-balancer` on the main Workbench container, but `/mnt/load-balancer` was absent from `XDG_CONFIG_DIRS`, so Workbench never discovered or read the file.

## Code Flow

`XDG_CONFIG_DIRS` is set in two places in `api/core/v1beta1/workbench_types.go`:

1. `InitializeNonRootSupervisorConfig` (~line 497) — the supervisord `Environment:` string used in NonRoot mode
2. `CreateVolumeFactory` (~line 696) — the `Env` var on the `"config-volume"` volume definition for the main pod

Both now include `/mnt/load-balancer` as the final path component, matching where the init container writes the config file.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `just test` and all tests pass
- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about