### PR TITLE
Add claude auto review

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -3,8 +3,55 @@ name: Claude Auto Review
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  review:
-    uses: posit-dev/ptd-workspace/.github/workflows/claude-auto-review.yml@main
-    secrets: inherit
+  auto-review:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@v1.0.110
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request,mcp__github_inline_comment__create_inline_comment"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+
+            Please review this PR following the guidelines in `.claude/review-guidelines.md` if it exists. Use the GitHub review system:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github_inline_comment__create_inline_comment` for specific line feedback, or `mcp__github__add_comment_to_pending_review` for general comments
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with:
+               - "APPROVE" in almost all cases — leave inline comments for suggestions, style, and non-critical issues alongside the approval
+               - "REQUEST_CHANGES" only for critical/blocking issues: security vulnerabilities, data loss risk, or broken functionality
+
+            Review priorities:
+            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
+            - **Correctness**: Logic errors, broken functionality, or data loss risk.
+            - **Simplicity**: Flag overly clever code or unclear intent, but as a suggestion not a blocker.
+
+            Default to APPROVE. Use inline comments freely for suggestions and observations.
+            Do not withhold approval because of style, minor improvements, or personal preference.
+            Keep comments concise and actionable.

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -3,19 +3,19 @@ name: Claude Auto Review
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: PR number to review
-        required: true
-        type: string
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  auto-review:
+  claude-review:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 30
@@ -24,34 +24,9 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
-      - name: Automatic PR Review
-        uses: anthropics/claude-code-action@v1.0.110
+      - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments,mcp__github__get_pull_request,mcp__github_inline_comment__create_inline_comment"
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-
-            Please review this PR following the guidelines in `.claude/review-guidelines.md` if it exists. Use the GitHub review system:
-
-            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
-            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github_inline_comment__create_inline_comment` for specific line feedback, or `mcp__github__add_comment_to_pending_review` for general comments
-            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with:
-               - "APPROVE" in almost all cases — leave inline comments for suggestions, style, and non-critical issues alongside the approval
-               - "REQUEST_CHANGES" only for critical/blocking issues: security vulnerabilities, data loss risk, or broken functionality
-
-            Review priorities:
-            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
-            - **Correctness**: Logic errors, broken functionality, or data loss risk.
-            - **Simplicity**: Flag overly clever code or unclear intent, but as a suggestion not a blocker.
-
-            Default to APPROVE. Use inline comments freely for suggestions and observations.
-            Do not withhold approval because of style, minor improvements, or personal preference.
-            Keep comments concise and actionable.

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -2,31 +2,52 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
+    types: [opened]
 
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
-  cancel-in-progress: false
+env:
+  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
 
 jobs:
-  claude-review:
+  auto-review:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
-    timeout-minutes: 30
+    if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
     permissions:
       contents: read
       pull-requests: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: anthropics/claude-code-action@v1
+
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
+          role-session-name: gha-claude-code-action
+          aws-region: us-east-2
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_bedrock: "true"
+          model: "us.anthropic.claude-opus-4-6-v1"
+          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+          timeout_minutes: "60"
+          claude_args: --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          prompt: |
+            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
+
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            Review priorities from guidelines:
+            - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
+            - **Maintainability**: Follow existing patterns. New code should look like it belongs.
+            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
+
+            Provide constructive feedback with specific suggestions for improvement.
+            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
+            Use inline comments to highlight specific areas of concern.

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -2,56 +2,9 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened]
-
-env:
-  PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
-  auto-review:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ env.PTD_AWS_ACCOUNT }}:role/claude-code
-          role-session-name: gha-claude-code-action
-          aws-region: us-east-2
-
-      - name: Automatic PR Review
-        uses: anthropics/claude-code-action@beta
-        if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
-        with:
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
-          use_bedrock: true
-          model: "us.anthropic.claude-opus-4-6-v1"
-          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-          timeout_minutes: "60"
-          direct_prompt: |
-            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
-
-            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
-            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
-            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
-
-            Review priorities from guidelines:
-            - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
-            - **Maintainability**: Follow existing patterns. New code should look like it belongs.
-            - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
-
-            Use the area-specific checklists from the guidelines for API changes, Controller changes, Helm chart, and Flightdeck.
-
-            Provide constructive feedback with specific suggestions for improvement.
-            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
-            Use inline comments to highlight specific areas of concern.
-
-            IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.
+  review:
+    uses: posit-dev/ptd-workspace/.github/workflows/claude-auto-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds automated Claude code review on PR open using Posit's existing Bedrock setup (`PTD_AWS_ACCOUNT` + `claude-code` IAM role).

- Auto-posts a non-blocking review comment when a PR is opened
- Skips bot-authored PRs (`posit-team-dedicated[bot]`)
- `@claude` mention support is handled by the existing `claude.yml` workflow
- Uses Bedrock via OIDC — no personal quota or API keys

**Changes from original workflow:**
- `@beta` → `@v1`
- `allowed_tools` → `claude_args: --allowedTools` (input renamed in v1)
- `direct_prompt` → `prompt` (input renamed in v1)
- Fixed tool name: `add_pull_request_review_comment_to_pending_review` → `add_comment_to_pending_review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)