### PR TITLE
ci: migrate Claude workflows to claude-code-action v1

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -6,10 +6,12 @@ on:
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 jobs:
   auto-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: read
@@ -27,15 +29,11 @@ jobs:
           aws-region: us-east-2
 
       - name: Automatic PR Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1.0.110
         if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
         with:
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
           use_bedrock: true
-          model: "us.anthropic.claude-opus-4-6-v1"
-          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-          timeout_minutes: "60"
-          direct_prompt: |
+          prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
 
             1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
@@ -55,3 +53,6 @@ jobs:
             Use inline comments to highlight specific areas of concern.
 
             IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.
+          claude_args: |
+            --model us.anthropic.claude-opus-4-6-v1
+            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 jobs:
   claude-code-action:
@@ -29,6 +30,7 @@ jobs:
         contains(github.event.issue.body, '@claude')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -58,17 +60,12 @@ jobs:
           aws-region: us-east-2
 
       - name: Run Claude Code Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1.0.110
         with:
-          model: "us.anthropic.claude-opus-4-6-v1"
-          fallback_model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-          timeout_minutes: "60"
           use_bedrock: true
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
-          custom_instructions: |
-            You are a helpful AI assistant for code reviews and issue triage.
-            Respond to comments and issues that mention you with relevant code suggestions or triage actions.
-            If you cannot assist, politely inform the user. In your responses, don't be overly complimentary.
-            Stick to the facts and provide actionable advice.
+          claude_args: |
+            --model us.anthropic.claude-opus-4-6-v1
+            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+            --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."


### PR DESCRIPTION
Bumps both Claude GitHub Actions workflows from `claude-code-action@beta` to `@v1.0.110`.

## Changes

- **`.github/workflows/claude.yml`** and **`.github/workflows/claude-auto-review.yml`**: pinned to `anthropics/claude-code-action@v1.0.110`.
- Folded the v0 inputs (`model`, `allowed_tools`, `custom_instructions`) into the new `claude_args` (`--model`, `--allowedTools`, `--append-system-prompt`).
- Renamed `direct_prompt` -> `prompt` in the auto-review workflow.
- Dropped `fallback_model` (no v1 equivalent) and `timeout_minutes` (now a job-level `timeout-minutes: 60`).
- Added `ANTHROPIC_DEFAULT_HAIKU_MODEL: us.anthropic.claude-haiku-4-5-20251001-v1:0` to each workflow's top-level `env`, replacing the implicit Claude 3.5 Haiku background model that hits Bedrock EOL on 2026-06-19.

Triggers, `if:` conditions, the actor permission check, checkout, and AWS credential steps are unchanged.