### PR TITLE
feat: add envVars field for Workbench, Connect, and Package Manager

### DIFF
--- a/api/core/v1beta1/connect_types.go
+++ b/api/core/v1beta1/connect_types.go
@@ -84,7 +84,12 @@ type ConnectSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// AddEnv adds arbitrary environment variables to the container env
+	//
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).
+	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
 	OffHostExecution bool `json:"offHostExecution,omitempty"`
 

--- a/api/core/v1beta1/connect_types.go
+++ b/api/core/v1beta1/connect_types.go
@@ -85,7 +85,9 @@ type ConnectSpec struct {
 
 	// AddEnv adds arbitrary environment variables to the container env
 	//
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).

--- a/api/core/v1beta1/packagemanager_types.go
+++ b/api/core/v1beta1/packagemanager_types.go
@@ -44,7 +44,9 @@ type PackageManagerSpec struct {
 
 	// AddEnv adds arbitrary environment variables to the container env
 	//
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).

--- a/api/core/v1beta1/packagemanager_types.go
+++ b/api/core/v1beta1/packagemanager_types.go
@@ -43,7 +43,12 @@ type PackageManagerSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// AddEnv adds arbitrary environment variables to the container env
+	//
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).
+	EnvVars []v1.EnvVar `json:"envVars,omitempty"`
 
 	Image string `json:"image,omitempty"`
 

--- a/api/core/v1beta1/site_types.go
+++ b/api/core/v1beta1/site_types.go
@@ -213,7 +213,9 @@ type InternalPackageManagerSpec struct {
 
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
@@ -284,7 +286,9 @@ type InternalConnectSpec struct {
 	// when they first log in via OAuth2/OIDC. Only applies when auth type is "oidc".
 	RegisterOnFirstLogin *bool `json:"registerOnFirstLogin,omitempty"`
 
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
@@ -420,7 +424,9 @@ type InternalWorkbenchSpec struct {
 	// If not specified, no superuser groups will be configured
 	AdminSuperuserGroups []string `json:"adminSuperuserGroups,omitempty"`
 
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`

--- a/api/core/v1beta1/site_types.go
+++ b/api/core/v1beta1/site_types.go
@@ -213,7 +213,10 @@ type InternalPackageManagerSpec struct {
 
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
 	Image string `json:"image,omitempty"`
 
@@ -281,7 +284,10 @@ type InternalConnectSpec struct {
 	// when they first log in via OAuth2/OIDC. Only applies when auth type is "oidc".
 	RegisterOnFirstLogin *bool `json:"registerOnFirstLogin,omitempty"`
 
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
 	Image string `json:"image,omitempty"`
 
@@ -414,7 +420,10 @@ type InternalWorkbenchSpec struct {
 	// If not specified, no superuser groups will be configured
 	AdminSuperuserGroups []string `json:"adminSuperuserGroups,omitempty"`
 
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
 	Auth AuthSpec `json:"auth,omitempty"`
 

--- a/api/core/v1beta1/workbench_types.go
+++ b/api/core/v1beta1/workbench_types.go
@@ -62,7 +62,9 @@ type WorkbenchSpec struct {
 
 	// AddEnv adds arbitrary environment variables to the container env
 	//
-	// Deprecated: use envVars instead.
+	// Deprecated: use envVars instead. If the same variable name is set in both
+	// addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+	// and Kubernetes resolves a duplicate env var name to the last occurrence.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
 
 	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).

--- a/api/core/v1beta1/workbench_types.go
+++ b/api/core/v1beta1/workbench_types.go
@@ -61,7 +61,12 @@ type WorkbenchSpec struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// AddEnv adds arbitrary environment variables to the container env
+	//
+	// Deprecated: use envVars instead.
 	AddEnv map[string]string `json:"addEnv,omitempty"`
+
+	// EnvVars adds environment variables to the container, supporting valueFrom (e.g. secretKeyRef).
+	EnvVars []corev1.EnvVar `json:"envVars,omitempty"`
 
 	OffHostExecution bool `json:"offHostExecution,omitempty"`
 

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -896,6 +896,13 @@ func (in *ConnectSpec) DeepCopyInto(out *ConnectSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.AdditionalRuntimeImages != nil {
 		in, out := &in.AdditionalRuntimeImages, &out.AdditionalRuntimeImages
 		*out = make([]ConnectRuntimeImageSpec, len(*in))
@@ -1228,6 +1235,13 @@ func (in *InternalConnectSpec) DeepCopyInto(out *InternalConnectSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Databricks != nil {
 		in, out := &in.Databricks, &out.Databricks
 		*out = new(DatabricksConfig)
@@ -1339,6 +1353,13 @@ func (in *InternalPackageManagerSpec) DeepCopyInto(out *InternalPackageManagerSp
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.GitSSHKeys != nil {
@@ -1493,6 +1514,13 @@ func (in *InternalWorkbenchSpec) DeepCopyInto(out *InternalWorkbenchSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	in.Auth.DeepCopyInto(&out.Auth)
@@ -1964,6 +1992,13 @@ func (in *PackageManagerSpec) DeepCopyInto(out *PackageManagerSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	out.Secret = in.Secret
@@ -3362,6 +3397,13 @@ func (in *WorkbenchSpec) DeepCopyInto(out *WorkbenchSpec) {
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
+		}
+	}
+	if in.EnvVars != nil {
+		in, out := &in.EnvVars, &out.EnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	out.Snowflake = in.Snowflake

--- a/client-go/applyconfiguration/core/v1beta1/connectspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/connectspec.go
@@ -26,6 +26,7 @@ type ConnectSpecApplyConfiguration struct {
 	ImagePullSecrets                     []string                                    `json:"imagePullSecrets,omitempty"`
 	NodeSelector                         map[string]string                           `json:"nodeSelector,omitempty"`
 	AddEnv                               map[string]string                           `json:"addEnv,omitempty"`
+	EnvVars                              []v1.EnvVar                                 `json:"envVars,omitempty"`
 	OffHostExecution                     *bool                                       `json:"offHostExecution,omitempty"`
 	AdditionalRuntimeImages              []ConnectRuntimeImageSpecApplyConfiguration `json:"additionalRuntimeImages,omitempty"`
 	Image                                *string                                     `json:"image,omitempty"`
@@ -174,6 +175,16 @@ func (b *ConnectSpecApplyConfiguration) WithAddEnv(entries map[string]string) *C
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *ConnectSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *ConnectSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/core/v1beta1/internalconnectspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalconnectspec.go
@@ -21,6 +21,7 @@ type InternalConnectSpecApplyConfiguration struct {
 	Auth                    *AuthSpecApplyConfiguration                            `json:"auth,omitempty"`
 	RegisterOnFirstLogin    *bool                                                  `json:"registerOnFirstLogin,omitempty"`
 	AddEnv                  map[string]string                                      `json:"addEnv,omitempty"`
+	EnvVars                 []v1.EnvVar                                            `json:"envVars,omitempty"`
 	Image                   *string                                                `json:"image,omitempty"`
 	SessionImage            *string                                                `json:"sessionImage,omitempty"`
 	ImagePullPolicy         *v1.PullPolicy                                         `json:"imagePullPolicy,omitempty"`
@@ -116,6 +117,16 @@ func (b *InternalConnectSpecApplyConfiguration) WithAddEnv(entries map[string]st
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *InternalConnectSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *InternalConnectSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/core/v1beta1/internalpackagemanagerspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalpackagemanagerspec.go
@@ -19,6 +19,7 @@ type InternalPackageManagerSpecApplyConfiguration struct {
 	Volume              *product.VolumeSpec                 `json:"volume,omitempty"`
 	NodeSelector        map[string]string                   `json:"nodeSelector,omitempty"`
 	AddEnv              map[string]string                   `json:"addEnv,omitempty"`
+	EnvVars             []v1.EnvVar                         `json:"envVars,omitempty"`
 	Image               *string                             `json:"image,omitempty"`
 	ImagePullPolicy     *v1.PullPolicy                      `json:"imagePullPolicy,omitempty"`
 	S3Bucket            *string                             `json:"s3Bucket,omitempty"`
@@ -94,6 +95,16 @@ func (b *InternalPackageManagerSpecApplyConfiguration) WithAddEnv(entries map[st
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *InternalPackageManagerSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *InternalPackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/core/v1beta1/internalworkbenchspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalworkbenchspec.go
@@ -28,6 +28,7 @@ type InternalWorkbenchSpecApplyConfiguration struct {
 	AdminGroups                   []string                                                 `json:"adminGroups,omitempty"`
 	AdminSuperuserGroups          []string                                                 `json:"adminSuperuserGroups,omitempty"`
 	AddEnv                        map[string]string                                        `json:"addEnv,omitempty"`
+	EnvVars                       []v1.EnvVar                                              `json:"envVars,omitempty"`
 	Auth                          *AuthSpecApplyConfiguration                              `json:"auth,omitempty"`
 	Image                         *string                                                  `json:"image,omitempty"`
 	ImagePullPolicy               *v1.PullPolicy                                           `json:"imagePullPolicy,omitempty"`
@@ -195,6 +196,16 @@ func (b *InternalWorkbenchSpecApplyConfiguration) WithAddEnv(entries map[string]
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *InternalWorkbenchSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *InternalWorkbenchSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/core/v1beta1/packagemanagerspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/packagemanagerspec.go
@@ -25,6 +25,7 @@ type PackageManagerSpecApplyConfiguration struct {
 	ImagePullSecrets             []string                                  `json:"imagePullSecrets,omitempty"`
 	NodeSelector                 map[string]string                         `json:"nodeSelector,omitempty"`
 	AddEnv                       map[string]string                         `json:"addEnv,omitempty"`
+	EnvVars                      []v1.EnvVar                               `json:"envVars,omitempty"`
 	Image                        *string                                   `json:"image,omitempty"`
 	ImagePullPolicy              *v1.PullPolicy                            `json:"imagePullPolicy,omitempty"`
 	Sleep                        *bool                                     `json:"sleep,omitempty"`
@@ -159,6 +160,16 @@ func (b *PackageManagerSpecApplyConfiguration) WithAddEnv(entries map[string]str
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *PackageManagerSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *PackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/core/v1beta1/workbenchspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/workbenchspec.go
@@ -31,6 +31,7 @@ type WorkbenchSpecApplyConfiguration struct {
 	NodeSelector                         map[string]string                         `json:"nodeSelector,omitempty"`
 	Tolerations                          []v1.Toleration                           `json:"tolerations,omitempty"`
 	AddEnv                               map[string]string                         `json:"addEnv,omitempty"`
+	EnvVars                              []v1.EnvVar                               `json:"envVars,omitempty"`
 	OffHostExecution                     *bool                                     `json:"offHostExecution,omitempty"`
 	Image                                *string                                   `json:"image,omitempty"`
 	ImagePullPolicy                      *v1.PullPolicy                            `json:"imagePullPolicy,omitempty"`
@@ -221,6 +222,16 @@ func (b *WorkbenchSpecApplyConfiguration) WithAddEnv(entries map[string]string) 
 	}
 	for k, v := range entries {
 		b.AddEnv[k] = v
+	}
+	return b
+}
+
+// WithEnvVars adds the given value to the EnvVars field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the EnvVars field.
+func (b *WorkbenchSpecApplyConfiguration) WithEnvVars(values ...v1.EnvVar) *WorkbenchSpecApplyConfiguration {
+	for i := range values {
+		b.EnvVars = append(b.EnvVars, values[i])
 	}
 	return b
 }

--- a/config/crd/bases/core.posit.team_connects.yaml
+++ b/config/crd/bases/core.posit.team_connects.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalRuntimeImages:
                 description: |-

--- a/config/crd/bases/core.posit.team_connects.yaml
+++ b/config/crd/bases/core.posit.team_connects.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalRuntimeImages:
                 description: |-
@@ -461,6 +463,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Connect sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/config/crd/bases/core.posit.team_packagemanagers.yaml
+++ b/config/crd/bases/core.posit.team_packagemanagers.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.

--- a/config/crd/bases/core.posit.team_packagemanagers.yaml
+++ b/config/crd/bases/core.posit.team_packagemanagers.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
@@ -240,6 +242,164 @@ spec:
                   sslMode:
                     type: string
                 type: object
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               gitSSHKeys:
                 description: |-
                   GitSSHKeys defines SSH key configurations for Git authentication

--- a/config/crd/bases/core.posit.team_sites.yaml
+++ b/config/crd/bases/core.posit.team_sites.yaml
@@ -96,7 +96,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -807,7 +810,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -1265,7 +1271,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfigs:
                     additionalProperties:

--- a/config/crd/bases/core.posit.team_sites.yaml
+++ b/config/crd/bases/core.posit.team_sites.yaml
@@ -96,6 +96,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -223,6 +224,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     properties:
                       chronicleSidecarProductApiKeyEnabled:
@@ -649,6 +807,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -736,6 +895,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   gitSSHKeys:
                     description: |-
                       GitSSHKeys defines SSH key configurations for Git authentication in Package Manager
@@ -949,6 +1265,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfigs:
                     additionalProperties:
@@ -1182,6 +1499,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     description: ExperimentalFeatures allows enabling miscellaneous
                       experimental features for workbench

--- a/config/crd/bases/core.posit.team_workbenches.yaml
+++ b/config/crd/bases/core.posit.team_workbenches.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's
@@ -652,6 +654,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Workbench sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/config/crd/bases/core.posit.team_workbenches.yaml
+++ b/config/crd/bases/core.posit.team_workbenches.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -76,8 +76,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalRuntimeImages:
                 description: |-
@@ -482,6 +484,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Connect sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -79,7 +79,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalRuntimeImages:
                 description: |-

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -79,7 +79,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -76,8 +76,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
@@ -261,6 +263,164 @@ spec:
                   sslMode:
                     type: string
                 type: object
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               gitSSHKeys:
                 description: |-
                   GitSSHKeys defines SSH key configurations for Git authentication

--- a/dist/chart/templates/crd/core.posit.team_sites.yaml
+++ b/dist/chart/templates/crd/core.posit.team_sites.yaml
@@ -117,7 +117,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -828,7 +831,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -1286,7 +1292,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfigs:
                     additionalProperties:

--- a/dist/chart/templates/crd/core.posit.team_sites.yaml
+++ b/dist/chart/templates/crd/core.posit.team_sites.yaml
@@ -117,6 +117,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -244,6 +245,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     properties:
                       chronicleSidecarProductApiKeyEnabled:
@@ -670,6 +828,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -757,6 +916,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   gitSSHKeys:
                     description: |-
                       GitSSHKeys defines SSH key configurations for Git authentication in Package Manager
@@ -970,6 +1286,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfigs:
                     additionalProperties:
@@ -1203,6 +1520,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     description: ExperimentalFeatures allows enabling miscellaneous
                       experimental features for workbench

--- a/dist/chart/templates/crd/core.posit.team_workbenches.yaml
+++ b/dist/chart/templates/crd/core.posit.team_workbenches.yaml
@@ -76,8 +76,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's
@@ -673,6 +675,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Workbench sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/dist/chart/templates/crd/core.posit.team_workbenches.yaml
+++ b/dist/chart/templates/crd/core.posit.team_workbenches.yaml
@@ -79,7 +79,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,7 +142,8 @@ The Connect CRD manages standalone Posit Connect deployments. When using the Sit
 | `.spec.ingressAnnotations` | `map[string]string` | No | Ingress annotations |
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.offHostExecution` | `bool` | No | Enable off-host execution (Kubernetes launcher) |
 | `.spec.image` | `string` | No | Connect container image |
 | `.spec.imagePullPolicy` | `PullPolicy` | No | Image pull policy |
@@ -231,7 +232,8 @@ The Workbench CRD manages standalone Posit Workbench deployments. When using the
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
 | `.spec.tolerations` | `[]Toleration` | No | Pod tolerations |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.offHostExecution` | `bool` | No | Enable off-host execution (Kubernetes launcher) |
 | `.spec.image` | `string` | No | Workbench container image |
 | `.spec.imagePullPolicy` | `PullPolicy` | No | Image pull policy |
@@ -313,7 +315,8 @@ The PackageManager CRD manages standalone Posit Package Manager deployments. Whe
 | `.spec.ingressAnnotations` | `map[string]string` | No | Ingress annotations |
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.image` | `string` | No | Package Manager container image |
 | `.spec.imagePullPolicy` | `PullPolicy` | No | Image pull policy |
 | `.spec.sleep` | `bool` | No | Put service to sleep (debugging) |
@@ -732,7 +735,8 @@ These types are used within the Site CRD for product configuration.
 | `.license` | `LicenseSpec` | License configuration |
 | `.volume` | `*VolumeSpec` | Data volume |
 | `.nodeSelector` | `map[string]string` | Node selector |
-| `.addEnv` | `map[string]string` | Environment variables |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.image` | `string` | Container image |
 | `.imagePullPolicy` | `PullPolicy` | Image pull policy |
 | `.s3Bucket` | `string` | S3 bucket for package storage |
@@ -751,7 +755,8 @@ These types are used within the Site CRD for product configuration.
 | `.volume` | `*VolumeSpec` | Data volume |
 | `.nodeSelector` | `map[string]string` | Node selector |
 | `.auth` | `AuthSpec` | Authentication configuration |
-| `.addEnv` | `map[string]string` | Environment variables |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.image` | `string` | Container image |
 | `.sessionImage` | `string` | Session container image |
 | `.imagePullPolicy` | `PullPolicy` | Image pull policy |
@@ -782,7 +787,8 @@ These types are used within the Site CRD for product configuration.
 | `.createUsersAutomatically` | `bool` | Auto-create users |
 | `.adminGroups` | `[]string` | Admin groups (default: ["workbench-admin"]) |
 | `.adminSuperuserGroups` | `[]string` | Superuser groups |
-| `.addEnv` | `map[string]string` | Environment variables |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.auth` | `AuthSpec` | Authentication configuration |
 | `.image` | `string` | Container image |
 | `.imagePullPolicy` | `PullPolicy` | Image pull policy |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,7 +142,7 @@ The Connect CRD manages standalone Posit Connect deployments. When using the Sit
 | `.spec.ingressAnnotations` | `map[string]string` | No | Ingress annotations |
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.offHostExecution` | `bool` | No | Enable off-host execution (Kubernetes launcher) |
 | `.spec.image` | `string` | No | Connect container image |
@@ -232,7 +232,7 @@ The Workbench CRD manages standalone Posit Workbench deployments. When using the
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
 | `.spec.tolerations` | `[]Toleration` | No | Pod tolerations |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.offHostExecution` | `bool` | No | Enable off-host execution (Kubernetes launcher) |
 | `.spec.image` | `string` | No | Workbench container image |
@@ -315,7 +315,7 @@ The PackageManager CRD manages standalone Posit Package Manager deployments. Whe
 | `.spec.ingressAnnotations` | `map[string]string` | No | Ingress annotations |
 | `.spec.imagePullSecrets` | `[]string` | No | Image pull secrets |
 | `.spec.nodeSelector` | `map[string]string` | No | Node selector for pod scheduling |
-| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars` instead. |
+| `.spec.addEnv` | `map[string]string` | No | Additional environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.spec.envVars` | `[]EnvVar` | No | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.spec.image` | `string` | No | Package Manager container image |
 | `.spec.imagePullPolicy` | `PullPolicy` | No | Image pull policy |
@@ -735,7 +735,7 @@ These types are used within the Site CRD for product configuration.
 | `.license` | `LicenseSpec` | License configuration |
 | `.volume` | `*VolumeSpec` | Data volume |
 | `.nodeSelector` | `map[string]string` | Node selector |
-| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.image` | `string` | Container image |
 | `.imagePullPolicy` | `PullPolicy` | Image pull policy |
@@ -755,7 +755,7 @@ These types are used within the Site CRD for product configuration.
 | `.volume` | `*VolumeSpec` | Data volume |
 | `.nodeSelector` | `map[string]string` | Node selector |
 | `.auth` | `AuthSpec` | Authentication configuration |
-| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.image` | `string` | Container image |
 | `.sessionImage` | `string` | Session container image |
@@ -787,7 +787,7 @@ These types are used within the Site CRD for product configuration.
 | `.createUsersAutomatically` | `bool` | Auto-create users |
 | `.adminGroups` | `[]string` | Admin groups (default: ["workbench-admin"]) |
 | `.adminSuperuserGroups` | `[]string` | Superuser groups |
-| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars` instead. |
+| `.addEnv` | `map[string]string` | Environment variables. **Deprecated:** use `envVars`; on a name conflict `envVars` wins. |
 | `.envVars` | `[]EnvVar` | Environment variables for the container, supporting `valueFrom` (e.g. `secretKeyRef`) |
 | `.auth` | `AuthSpec` | Authentication configuration |
 | `.image` | `string` | Container image |

--- a/internal/controller/core/connect.go
+++ b/internal/controller/core/connect.go
@@ -684,6 +684,7 @@ func (r *ConnectReconciler) ensureDeployedService(ctx context.Context, req ctrl.
 										Value: c.ComponentName(),
 									},
 								},
+								c.Spec.EnvVars,
 							),
 							Ports: []corev1.ContainerPort{
 								internal.DefaultPortConnectHTTP.ContainerPort("http"),

--- a/internal/controller/core/connect_test.go
+++ b/internal/controller/core/connect_test.go
@@ -528,6 +528,48 @@ func TestConnectReconciler_OIDC_DisableGroupsClaim(t *testing.T) {
 	assert.NotContains(t, config, "GroupsClaim = groups", "GroupsClaim should not have the default 'groups' value")
 }
 
+// TestConnectReconciler_EnvVars verifies that the envVars field, including a
+// valueFrom.secretKeyRef entry, flows through to the rendered Connect
+// container's Env.
+func TestConnectReconciler_EnvVars(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "connect-env-vars"
+
+	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
+
+	plainEnv := corev1.EnvVar{
+		Name:  "CONNECT_ENVVARS_TEST",
+		Value: "plain-value",
+	}
+	secretEnv := corev1.EnvVar{
+		Name: "CONNECT_ENVVARS_TEST_FROM_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+				Key:                  "api-key",
+			},
+		},
+	}
+
+	c := defineDefaultConnect(t, ns, name)
+	c.Spec.EnvVars = []corev1.EnvVar{plainEnv, secretEnv}
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)
+	require.NoError(t, err)
+
+	c = getConnect(t, cli, ns, name)
+
+	res, err := r.ReconcileConnect(ctx, req, c)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	deployment := getDeployment(t, cli, ns, c.ComponentName())
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Env, plainEnv, "plain envVar should be rendered into the container Env")
+	assert.Contains(t, container.Env, secretEnv, "secretKeyRef envVar should be rendered into the container Env")
+}
+
 // TestConnectReconciler_Suspended verifies that when Connect has Suspended=true,
 // ReconcileConnect does not create serving resources (Deployment, Service, Ingress).
 func TestConnectReconciler_Suspended(t *testing.T) {

--- a/internal/controller/core/package_manager.go
+++ b/internal/controller/core/package_manager.go
@@ -521,6 +521,7 @@ func (r *PackageManagerReconciler) ensureDeployedService(ctx context.Context, re
 								secretVolumeFactory.EnvVars(),
 								product.StringMapToEnvVars(pm.Spec.AddEnv),
 								[]corev1.EnvVar{},
+								pm.Spec.EnvVars,
 							),
 							Ports: []corev1.ContainerPort{
 								internal.DefaultPortPackageManagerHTTP.ContainerPort("http"),

--- a/internal/controller/core/package_manager_controller_test.go
+++ b/internal/controller/core/package_manager_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,4 +144,70 @@ func TestPackageManagerReconciler_DeploymentHasProbes(t *testing.T) {
 	assert.Equal(t, "/__ping__", container.LivenessProbe.HTTPGet.Path)
 	assert.Equal(t, httpPort, container.LivenessProbe.HTTPGet.Port)
 	assert.Equal(t, int32(10), container.LivenessProbe.InitialDelaySeconds)
+}
+
+// TestPackageManagerReconciler_EnvVars verifies that the envVars field, including a
+// valueFrom.secretKeyRef entry, flows through to the rendered Package Manager
+// container's Env.
+func TestPackageManagerReconciler_EnvVars(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "pm-env-vars"
+
+	fakeEnv := localtest.FakeTestEnv{}
+	cli, scheme, log := fakeEnv.Start(loadSchemes)
+
+	r := &PackageManagerReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log,
+	}
+
+	ctx = logr.NewContext(ctx, log)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	}
+
+	plainEnv := corev1.EnvVar{
+		Name:  "PM_PLAIN",
+		Value: "plain-value",
+	}
+	secretEnv := corev1.EnvVar{
+		Name: "PM_FROM_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+				Key:                  "api-key",
+			},
+		},
+	}
+
+	pm := &positcov1beta1.PackageManager{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManager",
+			APIVersion: "core.posit.team/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: "pm-env-vars-uid"},
+		Spec: positcov1beta1.PackageManagerSpec{
+			Image: "ghcr.io/rstudio/rstudio-pm:test",
+			Secret: positcov1beta1.SecretConfig{
+				Type: product.SiteSecretKubernetes,
+			},
+			Config:  &positcov1beta1.PackageManagerConfig{},
+			EnvVars: []corev1.EnvVar{plainEnv, secretEnv},
+		},
+	}
+
+	require.NoError(t, cli.Create(ctx, pm))
+
+	_, err := r.ensureDeployedService(ctx, req, pm)
+	require.NoError(t, err)
+
+	dep := &appsv1.Deployment{}
+	err = cli.Get(ctx, client.ObjectKey{Name: pm.ComponentName(), Namespace: ns}, dep)
+	require.NoError(t, err)
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Env, plainEnv, "plain envVar should be rendered into the container Env")
+	assert.Contains(t, container.Env, secretEnv, "secretKeyRef envVar should be rendered into the container Env")
 }

--- a/internal/controller/core/site_controller_connect.go
+++ b/internal/controller/core/site_controller_connect.go
@@ -145,6 +145,7 @@ func (r *SiteReconciler) reconcileConnect(
 			AdditionalVolumes:            additionalVolumes,
 			NodeSelector:                 site.Spec.Connect.NodeSelector,
 			AddEnv:                       site.Spec.Connect.AddEnv,
+			EnvVars:                      site.Spec.Connect.EnvVars,
 			// default to true...
 			OffHostExecution:        true,
 			AdditionalRuntimeImages: site.Spec.Connect.AdditionalRuntimeImages,

--- a/internal/controller/core/site_controller_package_manager.go
+++ b/internal/controller/core/site_controller_package_manager.go
@@ -99,6 +99,7 @@ func (r *SiteReconciler) reconcilePackageManager(
 			ChronicleAgentImage:          site.Spec.Chronicle.AgentImage,
 			NodeSelector:                 site.Spec.PackageManager.NodeSelector,
 			AddEnv:                       site.Spec.PackageManager.AddEnv,
+			EnvVars:                      site.Spec.PackageManager.EnvVars,
 			Secret:                       site.Spec.Secret,
 			WorkloadSecret:               site.Spec.WorkloadSecret,
 			Replicas:                     product.PassDefaultReplicas(site.Spec.PackageManager.Replicas, 1),

--- a/internal/controller/core/site_controller_workbench.go
+++ b/internal/controller/core/site_controller_workbench.go
@@ -262,6 +262,7 @@ func (r *SiteReconciler) reconcileWorkbench(
 			NodeSelector:                 site.Spec.Workbench.NodeSelector,
 			Tolerations:                  site.Spec.Workbench.Tolerations,
 			AddEnv:                       site.Spec.Workbench.AddEnv,
+			EnvVars:                      site.Spec.Workbench.EnvVars,
 			Auth:                         site.Spec.Workbench.Auth,
 			Secret:                       site.Spec.Secret,
 			WorkloadSecret:               site.Spec.WorkloadSecret,

--- a/internal/controller/core/site_test.go
+++ b/internal/controller/core/site_test.go
@@ -244,6 +244,54 @@ func TestSiteReconciler_SessionEnvVars(t *testing.T) {
 	assert.Equal(t, "some-value", testConnect.Spec.SessionConfig.Pod.Env[0].Value)
 }
 
+// TestSiteReconciler_EnvVars verifies that the new envVars field, including a
+// valueFrom.secretKeyRef entry, propagates from the Site spec to each product CR
+// spec for Workbench, Connect, and Package Manager.
+func TestSiteReconciler_EnvVars(t *testing.T) {
+	siteName := "env-vars"
+	siteNamespace := "posit-team"
+	site := defaultSite(siteName)
+
+	envVars := func(prefix string) []corev1.EnvVar {
+		return []corev1.EnvVar{
+			{
+				Name:  prefix + "_PLAIN",
+				Value: "plain-value",
+			},
+			{
+				Name: prefix + "_FROM_SECRET",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+						Key:                  "api-key",
+					},
+				},
+			},
+		}
+	}
+
+	site.Spec.Workbench.EnvVars = envVars("WB")
+	site.Spec.Connect.EnvVars = envVars("CONNECT")
+	site.Spec.PackageManager.EnvVars = envVars("PM")
+
+	cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+	assert.Nil(t, err)
+
+	assertEnvVars := func(t *testing.T, prefix string, got []corev1.EnvVar) {
+		t.Helper()
+		assert.Equal(t, envVars(prefix), got)
+	}
+
+	testWorkbench := getWorkbench(t, cli, siteNamespace, siteName)
+	assertEnvVars(t, "WB", testWorkbench.Spec.EnvVars)
+
+	testConnect := getConnect(t, cli, siteNamespace, siteName)
+	assertEnvVars(t, "CONNECT", testConnect.Spec.EnvVars)
+
+	testPackageManager := getPackageManager(t, cli, siteNamespace, siteName)
+	assertEnvVars(t, "PM", testPackageManager.Spec.EnvVars)
+}
+
 func TestSiteLoggingAndDebug(t *testing.T) {
 	siteName := "logging-site"
 	siteNamespace := "posit-team"

--- a/internal/controller/core/workbench.go
+++ b/internal/controller/core/workbench.go
@@ -890,6 +890,7 @@ func (r *WorkbenchReconciler) ensureDeployedService(ctx context.Context, req ctr
 											Value: w.ComponentName(),
 										},
 									},
+									w.Spec.EnvVars,
 								),
 								Command: []string{"supervisord"},
 								Args:    []string{},

--- a/internal/controller/core/workbench_test.go
+++ b/internal/controller/core/workbench_test.go
@@ -437,6 +437,48 @@ func TestWorkbenchPodDisruptionBudgets(t *testing.T) {
 		"Session PDB should have maxUnavailable=0 to prevent session evictions")
 }
 
+// TestWorkbenchReconciler_EnvVars verifies that the envVars field, including a
+// valueFrom.secretKeyRef entry, flows through to the rendered Workbench
+// container's Env.
+func TestWorkbenchReconciler_EnvVars(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "workbench-env-vars"
+
+	ctx, r, req, cli := initWorkbenchReconciler(t, ctx, ns, name)
+
+	plainEnv := corev1.EnvVar{
+		Name:  "WORKBENCH_ENVVARS_TEST",
+		Value: "plain-value",
+	}
+	secretEnv := corev1.EnvVar{
+		Name: "WORKBENCH_ENVVARS_TEST_FROM_SECRET",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+				Key:                  "api-key",
+			},
+		},
+	}
+
+	wb := defineDefaultWorkbench(t, ns, name)
+	wb.Spec.EnvVars = []corev1.EnvVar{plainEnv, secretEnv}
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Workbench{}, wb)
+	require.NoError(t, err)
+
+	wb = getWorkbench(t, cli, ns, name)
+
+	res, err := r.ReconcileWorkbench(ctx, req, wb)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	deployment := getDeployment(t, cli, ns, wb.ComponentName())
+	mainContainer := deployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, mainContainer.Env, plainEnv, "plain envVar should be rendered into the container Env")
+	assert.Contains(t, mainContainer.Env, secretEnv, "secretKeyRef envVar should be rendered into the container Env")
+}
+
 // TestWorkbenchReconciler_Suspended verifies that when Workbench has Suspended=true,
 // ReconcileWorkbench does not create serving resources (Deployment, Service, Ingress).
 func TestWorkbenchReconciler_Suspended(t *testing.T) {

--- a/internal/crdapply/bases/core.posit.team_connects.yaml
+++ b/internal/crdapply/bases/core.posit.team_connects.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalRuntimeImages:
                 description: |-

--- a/internal/crdapply/bases/core.posit.team_connects.yaml
+++ b/internal/crdapply/bases/core.posit.team_connects.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalRuntimeImages:
                 description: |-
@@ -461,6 +463,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Connect sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
+++ b/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.

--- a/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
+++ b/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
@@ -240,6 +242,164 @@ spec:
                   sslMode:
                     type: string
                 type: object
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               gitSSHKeys:
                 description: |-
                   GitSSHKeys defines SSH key configurations for Git authentication

--- a/internal/crdapply/bases/core.posit.team_sites.yaml
+++ b/internal/crdapply/bases/core.posit.team_sites.yaml
@@ -96,7 +96,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -807,7 +810,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -1265,7 +1271,10 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
-                    description: 'Deprecated: use envVars instead.'
+                    description: |-
+                      Deprecated: use envVars instead. If the same variable name is set in both
+                      addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                      and Kubernetes resolves a duplicate env var name to the last occurrence.
                     type: object
                   additionalConfigs:
                     additionalProperties:

--- a/internal/crdapply/bases/core.posit.team_sites.yaml
+++ b/internal/crdapply/bases/core.posit.team_sites.yaml
@@ -96,6 +96,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -223,6 +224,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     properties:
                       chronicleSidecarProductApiKeyEnabled:
@@ -649,6 +807,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfig:
                     description: AdditionalConfig allows appending arbitrary gcfg
@@ -736,6 +895,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   gitSSHKeys:
                     description: |-
                       GitSSHKeys defines SSH key configurations for Git authentication in Package Manager
@@ -949,6 +1265,7 @@ spec:
                   addEnv:
                     additionalProperties:
                       type: string
+                    description: 'Deprecated: use envVars instead.'
                     type: object
                   additionalConfigs:
                     additionalProperties:
@@ -1182,6 +1499,163 @@ spec:
                       but preserves PVC, database, and secrets so data is retained.
                       Re-enabling restores full service without data loss.
                     type: boolean
+                  envVars:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                   experimentalFeatures:
                     description: ExperimentalFeatures allows enabling miscellaneous
                       experimental features for workbench

--- a/internal/crdapply/bases/core.posit.team_workbenches.yaml
+++ b/internal/crdapply/bases/core.posit.team_workbenches.yaml
@@ -55,8 +55,10 @@ spec:
               addEnv:
                 additionalProperties:
                   type: string
-                description: AddEnv adds arbitrary environment variables to the container
-                  env
+                description: |-
+                  AddEnv adds arbitrary environment variables to the container env
+
+                  Deprecated: use envVars instead.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's
@@ -652,6 +654,164 @@ spec:
                 description: DsnSecret is the name of the secret that contains the
                   DSN to include with all Workbench sessions
                 type: string
+              envVars:
+                description: EnvVars adds environment variables to the container,
+                  supporting valueFrom (e.g. secretKeyRef).
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:

--- a/internal/crdapply/bases/core.posit.team_workbenches.yaml
+++ b/internal/crdapply/bases/core.posit.team_workbenches.yaml
@@ -58,7 +58,9 @@ spec:
                 description: |-
                   AddEnv adds arbitrary environment variables to the container env
 
-                  Deprecated: use envVars instead.
+                  Deprecated: use envVars instead. If the same variable name is set in both
+                  addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
+                  and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
               additionalVolumes:
                 description: AdditionalVolumes represents additional VolumeSpec's


### PR DESCRIPTION
## Summary

Adds a new `envVars` field (`[]corev1.EnvVar`) to the **Workbench**, **Connect**, and **Package Manager** product specs (both the standalone product CRs and the Site-embedded specs). Unlike the existing `addEnv` (`map[string]string`, literals only), `envVars` supports the standard Kubernetes `EnvVar` structure including `valueFrom` (e.g. `secretKeyRef`), so secrets can be injected the Kubernetes-native way.

The existing `addEnv` field is **deprecated** in favor of `envVars` but continues to work. `envVars` is appended last when assembling the container `Env`, so it takes precedence on a name conflict.

Scope is intentionally limited to the three "product itself" pods. Workbench sessions already have `sessionEnvVars`; Connect content and Chronicle are not included.

## Usage

```yaml
apiVersion: core.posit.team/v1beta1
kind: Site
spec:
  packageManager:
    envVars:
      - name: PM_API_KEY
        valueFrom:
          secretKeyRef:
            name: my-secret
            key: api-key
```

The same `envVars` field is available under `spec.connect` and `spec.workbench`.

## Changes

- API types: `envVars` added to Connect/Workbench/PackageManager specs and their Site-embedded internal specs; `addEnv` marked deprecated.
- Controllers: Site → product copy of `envVars`; `envVars` appended to the container `Env` render path for all three products.
- Regenerated: deepcopy, CRD bases (+ embedded copies), Helm chart CRDs, client-go applyconfiguration, openapi.
- Docs: `docs/api-reference.md` updated with `envVars` rows and `addEnv` deprecation notes.

## Testing

- `TestSiteReconciler_EnvVars` — verifies Site → product CR propagation (including a `secretKeyRef` entry) for all three products.
- `TestPackageManagerReconciler_EnvVars` — verifies both a plain var and a `secretKeyRef` var reach the rendered Package Manager container `Env`.
- `make manifests generate-all` idempotent, `make verify-crds`, `make fmt vet build`, and `make test` all pass.