### PR TITLE
ci: upgrade Claude actions to Sonnet 4.6, fix tool name

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -53,4 +53,4 @@ jobs:
             Use inline comments to highlight specific areas of concern.
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+            --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -52,5 +52,5 @@ jobs:
             Don't be overly complimentary; focus on actionable insights and keep your comments concise.
             Use inline comments to highlight specific areas of concern.
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -38,7 +38,7 @@ jobs:
 
             1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
             2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github__add_pull_request_review_comment_to_pending_review` for each specific piece of feedback on particular lines
+            3. **Add inline comments**: Use `mcp__github__add_comment_to_pending_review` for each specific piece of feedback on particular lines
             4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
 
             Review priorities from guidelines:
@@ -51,8 +51,6 @@ jobs:
             Provide constructive feedback with specific suggestions for improvement.
             Don't be overly complimentary; focus on actionable insights and keep your comments concise.
             Use inline comments to highlight specific areas of concern.
-
-            IMPORTANT: Do NOT post any additional comments after submitting the review. The GitHub review itself is sufficient and any additional summary comments will be redundant.
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1
-            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
-  ANTHROPIC_DEFAULT_HAIKU_MODEL: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 jobs:
   auto-review:

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -52,5 +52,5 @@ jobs:
             Don't be overly complimentary; focus on actionable insights and keep your comments concise.
             Use inline comments to highlight specific areas of concern.
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
             --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,6 @@ on:
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
-  ANTHROPIC_DEFAULT_HAIKU_MODEL: "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 jobs:
   claude-code-action:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,6 +66,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1
-            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,5 +67,5 @@ jobs:
           additional_permissions: "actions: read"
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+            --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,6 +66,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-6-20250514-v1:0
+            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
             --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,6 +66,6 @@ jobs:
           branch_prefix: "claude-"
           additional_permissions: "actions: read"
           claude_args: |
-            --model us.anthropic.claude-sonnet-4-5-20250929-v1:0
+            --model us.anthropic.claude-sonnet-4-6
             --allowedTools "mcp__github__create_pull_request,mcp__github__create_issue,mcp__github__search_issues,mcp__github__update_issue,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
             --append-system-prompt "You are a helpful AI assistant for code reviews and issue triage. Respond to comments and issues that mention you with relevant code suggestions or triage actions. If you cannot assist, politely inform the user. In your responses, don't be overly complimentary. Stick to the facts and provide actionable advice."


### PR DESCRIPTION
Upgrades both Claude workflows to Sonnet 4.6 and fixes several issues found during testing.

- Switches model to Sonnet 4.6 (`us.anthropic.claude-sonnet-4-6`) in both `claude-auto-review.yml` and `claude.yml`
- Fixes wrong MCP tool name (`add_pull_request_review_comment_to_pending_review` → `add_comment_to_pending_review`)
- Expands `--allowedTools` to include read tools Claude needs for PR context (`get_pull_request`, `get_pull_request_files`, `get_pull_request_reviews`, `get_pull_request_review_comments`) — without these, Claude completed with permission denials every run and posted nothing
- Removes `ANTHROPIC_DEFAULT_HAIKU_MODEL` env var — Sonnet 4.6 is used for everything
- Grants `pull-requests: write` so Claude can actually post review comments