### PR TITLE
fix: correct load-balancer XDG_CONFIG_DIRS path so Workbench finds config

### DIFF
--- a/api/core/v1beta1/workbench_types.go
+++ b/api/core/v1beta1/workbench_types.go
@@ -509,7 +509,10 @@ func (w *Workbench) InitializeNonRootSupervisorConfig(ctx context.Context, confi
 			StdOutLogFileMaxBytes: 0,
 			StdErrLogFile:         "/dev/stderr",
 			StdErrLogFileMaxBytes: 0,
-			Environment:           `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer/rstudio"`,
+			// XDG_CONFIG_DIRS entries are base dirs; Workbench appends "rstudio/<file>"
+			// to each. The load-balancer config lives at /mnt/load-balancer/rstudio/load-balancer,
+			// so the entry must be /mnt/load-balancer (NOT /mnt/load-balancer/rstudio).
+			Environment: `XDG_CONFIG_DIRS="/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer"`,
 		},
 	}
 	return nil
@@ -707,8 +710,11 @@ func (w *Workbench) CreateVolumeFactory(cfg *WorkbenchConfig) *product.VolumeFac
 			Mounts: configVolumeMounts,
 			Env: []corev1.EnvVar{
 				{
+					// XDG_CONFIG_DIRS entries are base dirs; Workbench appends "rstudio/<file>"
+					// to each. The load-balancer config lives at /mnt/load-balancer/rstudio/load-balancer,
+					// so the entry must be /mnt/load-balancer (NOT /mnt/load-balancer/rstudio).
 					Name:  "XDG_CONFIG_DIRS",
-					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer/rstudio",
+					Value: "/mnt/config/rstudio:/mnt/config:/mnt/secure:/mnt/secure-config:/mnt/session:/mnt/load-balancer",
 				},
 				{
 					Name: "RSW_TESTUSER_PASSWD",


### PR DESCRIPTION
## Description

Fixes the Workbench HA load-balancer config never being read, which caused nodes to fall back to pod hostnames (unresolvable in cluster DNS) and fail to reach each other.

### Root cause

`XDG_CONFIG_DIRS` entries are *base* directories — Workbench appends `rstudio/<filename>` to each when resolving config files. The load-balancer init container writes its config to `/mnt/load-balancer/rstudio/load-balancer`, so the XDG entry must be `/mnt/load-balancer`.

The entry was `/mnt/load-balancer/rstudio`, so Workbench looked for `/mnt/load-balancer/rstudio/rstudio/load-balancer`, which never exists. On startup Workbench logged:

```
No load balancing configuration 'load-balancer' found in XDG_CONFIG_DIRS, expected in an 'rstudio' folder in one of '...:/mnt/load-balancer/rstudio'
Load balancer default for missing www-host-name using system hostname: <pod-name>:8787
```

Because `www-host-name` defaulted to the pod name (not the pod IP from the load-balancer file), HA nodes tried to reach each other by pod hostname, which is not resolvable via cluster DNS:

```
ERROR asio.netdb error 1 (Host not found (authoritative)) [host: <pod-name>:8787, uri: /load-balancer/distributed_events ...]
```

This degraded session routing in multi-replica Workbench deployments (failed distributed events, white screens on session creation).

### Fix

Set the XDG entry to `/mnt/load-balancer` in both locations (`InitializeNonRootSupervisorConfig` and `CreateVolumeFactory`), and add a comment explaining the base-dir semantics to prevent regression. The previous value was introduced during review of #129, which had originally used the correct path.

### Verification

Reproduced on a staging cluster: a freshly rolled Workbench pod logged the "No load balancing configuration found" message and defaulted `www-host-name` to the pod name. With the corrected path, Workbench reads the file and uses the pod IP.

## Category of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Tests pass (`make go-test`, exit 0)
- [x] Reviewed my own diff