### PR TITLE
feat(workbench): default launcher-sessions-proxy-timeout-seconds to 2

### DIFF
--- a/internal/controller/core/site_controller_workbench.go
+++ b/internal/controller/core/site_controller_workbench.go
@@ -63,7 +63,10 @@ func (r *SiteReconciler) reconcileWorkbench(
 	}
 
 	threadPoolSize := 16
-	proxyMaxWaitSecs := 30
+	// The Workbench team suggested launcher-sessions-proxy-timeout-seconds=2 is a better
+	// default for Kubernetes environments. Set as the managed default; a Site can still
+	// override it via Workbench.ExperimentalFeatures.LauncherSessionsProxyTimeoutSeconds.
+	proxyMaxWaitSecs := 2
 	vsCodeArgs := "--host=0.0.0.0"
 	resourceProfiles := defaultWorkbenchResourceProfiles()
 	if site.Spec.Workbench.ExperimentalFeatures != nil {

--- a/internal/controller/core/site_test.go
+++ b/internal/controller/core/site_test.go
@@ -204,6 +204,37 @@ func TestSiteReconciler_ReadinessProbePath(t *testing.T) {
 	})
 }
 
+func TestSiteReconciler_LauncherSessionsProxyTimeout(t *testing.T) {
+	t.Run("default_is_two", func(t *testing.T) {
+		siteName := "proxy-timeout-default"
+		siteNamespace := "posit-team"
+		site := defaultSite(siteName)
+
+		cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+		assert.Nil(t, err)
+
+		testWorkbench := getWorkbench(t, cli, siteNamespace, siteName)
+		require.NotNil(t, testWorkbench.Spec.Config.RServer)
+		assert.Equal(t, 2, testWorkbench.Spec.Config.RServer.LauncherSessionsProxyTimeoutSeconds)
+	})
+
+	t.Run("override_propagates", func(t *testing.T) {
+		siteName := "proxy-timeout-override"
+		siteNamespace := "posit-team"
+		site := defaultSite(siteName)
+		site.Spec.Workbench.ExperimentalFeatures = &v1beta1.InternalWorkbenchExperimentalFeatures{
+			LauncherSessionsProxyTimeoutSeconds: ptr.To(45),
+		}
+
+		cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+		assert.Nil(t, err)
+
+		testWorkbench := getWorkbench(t, cli, siteNamespace, siteName)
+		require.NotNil(t, testWorkbench.Spec.Config.RServer)
+		assert.Equal(t, 45, testWorkbench.Spec.Config.RServer.LauncherSessionsProxyTimeoutSeconds)
+	})
+}
+
 func TestSiteReconciler_SessionEnvVars(t *testing.T) {
 	siteName := "session-env-vars"
 	siteNamespace := "posit-team"


### PR DESCRIPTION
The Workbench team suggested 2 seconds is a better `launcher-sessions-proxy-timeout-seconds` default for Kubernetes environments (previously 30). Sites can still override it via `Workbench.ExperimentalFeatures.LauncherSessionsProxyTimeoutSeconds`.

## Testing
- New unit tests cover the default and the override path.
- `just test` passes.