### PR TITLE
fix: make auto-review post (track_progress), trigger on ready, skip drafts

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -32,6 +32,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.110
         with:
           use_bedrock: true
+          track_progress: "true"
           prompt: |
             Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
 

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -52,4 +52,4 @@ jobs:
             Use inline comments to highlight specific areas of concern.
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "Read,Glob,Grep,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
+            --disallowedTools "Bash,Edit,Write,MultiEdit,NotebookEdit,WebFetch"

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -32,25 +32,25 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.110
         with:
           use_bedrock: true
-          track_progress: "true"
+          track_progress: true
           prompt: |
-            Please review this PR following the guidelines in `.claude/review-guidelines.md`. Use the GitHub review system:
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
-            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
-            3. **Add inline comments**: Use `mcp__github__add_comment_to_pending_review` for each specific piece of feedback on particular lines
-            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+            Review this pull request following the guidelines in `.claude/review-guidelines.md`.
+            Use the area-specific checklists from the guidelines for API changes, Controller
+            changes, Helm chart, and Flightdeck.
 
-            Review priorities from guidelines:
+            Use inline comments for specific line-level feedback, and a single top-level
+            comment for general observations. Post comments only — do NOT approve or
+            request changes.
+
+            Review priorities from the guidelines:
             - **Simplicity**: Code should be explicit, not clever. Functions do one thing. Names reveal intent.
             - **Maintainability**: Follow existing patterns. New code should look like it belongs.
             - **Security (elevated scrutiny)**: Extra attention for file system, network, credentials, RBAC, and IAM changes.
 
-            Use the area-specific checklists from the guidelines for API changes, Controller changes, Helm chart, and Flightdeck.
-
-            Provide constructive feedback with specific suggestions for improvement.
-            Don't be overly complimentary; focus on actionable insights and keep your comments concise.
-            Use inline comments to highlight specific areas of concern.
+            Don't be overly complimentary; keep feedback concise and actionable.
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --disallowedTools "Bash,Edit,Write,MultiEdit,NotebookEdit,WebFetch"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   auto-review:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'posit-team-dedicated[bot]' }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -29,7 +30,6 @@ jobs:
 
       - name: Automatic PR Review
         uses: anthropics/claude-code-action@v1.0.110
-        if: github.event.pull_request.user.login != 'posit-team-dedicated[bot]'
         with:
           use_bedrock: true
           prompt: |

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 env:
   PTD_AWS_ACCOUNT: ${{ secrets.PTD_AWS_ACCOUNT }}
@@ -52,4 +52,4 @@ jobs:
             Use inline comments to highlight specific areas of concern.
           claude_args: |
             --model us.anthropic.claude-sonnet-4-6
-            --allowedTools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"
+            --allowedTools "Read,Glob,Grep,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_review_comments"


### PR DESCRIPTION
Consolidated fixes so the auto-review actually runs and posts:

- **`track_progress: "true"`** — the key fix. In automation mode claude-code-action runs the review but doesn't publish it without this; runs were completing with 0 denials but posting nothing. Mirrors the review-actions wrapper used by ptd-config.
- **Trigger on `ready_for_review`** — previously only `opened`, so draft→ready did nothing.
- **Skip drafts** — job guard `!github.event.pull_request.draft`, consolidated with the existing bot-author check into one job-level `if`.
- **Tool denylist** instead of the narrow allowlist, so Claude can read `.claude/review-guidelines.md` and repo files (was hitting permission denials and bailing).

> ⚠️ Can't be verified on this PR (claude-code-action requires the workflow file to match the default branch); confirmation is on the next normal PR after merge.