### PR TITLE
fix: prevent YAML line-wrap in Workbench job launcher template

### DIFF
--- a/api/templates/2.5.0/job.tpl
+++ b/api/templates/2.5.0/job.tpl
@@ -49,8 +49,8 @@ spec:
         {{- end }}
         stdin: {{ toYaml .Job.stdin | indent 8 | trimPrefix (repeat 8 " ") }}
         user: {{ toYaml .Job.user }}
-        name: {{ toYaml .Job.name }}
-        service_ports: {{ toYaml .Job.servicePortsJson }}
+        name: {{ toYaml .Job.name | indent 8 | trimPrefix (repeat 8 " ") }}
+        service_ports: {{ toYaml .Job.servicePortsJson | indent 8 | trimPrefix (repeat 8 " ") }}
         {{- if .Job.metadata }}
         user_metadata: {{ toJson .Job.metadata | toYaml | indent 8 | trimPrefix (repeat 8 " ") }}
         {{- end }}


### PR DESCRIPTION
## Summary

Replicates the fix from [rstudio/helm#795](https://github.com/rstudio/helm/pull/795) into team-operator's vendored Workbench launcher job template.

Go's `yaml.Marshal` wraps strings at 80 characters by default. In `job.tpl`, the `name` annotation (session name + IDs + username + project name) and the `service_ports` annotation (JSON port mappings) can exceed 80 chars. When they wrap, the continuation line lands at the wrong indentation, producing invalid YAML that Kubernetes rejects with a `400 Bad Request` — breaking Workbench session launch for users with long project names or many service ports.

## Fix

Add the `| indent 8 | trimPrefix (repeat 8 " ")` guard to the `name` and `service_ports` lines, matching the pattern already used by the adjacent `stdin` and `user_metadata` annotations:

```diff
-        name: {{ toYaml .Job.name }}
-        service_ports: {{ toYaml .Job.servicePortsJson }}
+        name: {{ toYaml .Job.name | indent 8 | trimPrefix (repeat 8 " ") }}
+        service_ports: {{ toYaml .Job.servicePortsJson | indent 8 | trimPrefix (repeat 8 " ") }}
```

Applied to `api/templates/2.5.0/job.tpl` — the only version embedded and used by the operator (`//go:embed 2.5.0/job.tpl`, consumed by workbench.go and connect.go). The `2.4.0`/`2.3.1` directories are unreferenced historical copies and are intentionally left untouched.

## Testing

- [ ] Deploy adhoc image to a test cluster and launch a Workbench session with a long project name / multiple service ports; confirm the launcher job applies cleanly.

There are currently no template-rendering tests for `job.tpl` in this repo. A follow-up unit test that renders the template with a long `name`/`servicePortsJson` and asserts the output parses as valid YAML would guard against regression (out of scope here).
