### PR TITLE
feat(chronicle): make chronicle-server resources configurable

### DIFF
--- a/api/core/v1beta1/chronicle_types.go
+++ b/api/core/v1beta1/chronicle_types.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/posit-dev/team-operator/api/product"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,6 +26,10 @@ type ChronicleSpec struct {
 	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`
 
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Resources sets the chronicle-server container's resource requests/limits.
+	// If unset, product defaults are applied. Setting this replaces the defaults entirely.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// AddEnv adds arbitrary environment variables to the container env
 	AddEnv map[string]string `json:"addEnv,omitempty"`

--- a/api/core/v1beta1/site_types.go
+++ b/api/core/v1beta1/site_types.go
@@ -627,6 +627,10 @@ type InternalChronicleSpec struct {
 
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// Resources sets the chronicle-server container's resource requests/limits.
+	// If unset, product defaults are applied. Setting this replaces the defaults entirely.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
 	Image string `json:"image,omitempty"`
 
 	AddEnv map[string]string `json:"addEnv,omitempty"`

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -340,6 +340,11 @@ func (in *ChronicleSpec) DeepCopyInto(out *ChronicleSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AddEnv != nil {
 		in, out := &in.AddEnv, &out.AddEnv
 		*out = make(map[string]string, len(*in))
@@ -1159,6 +1164,11 @@ func (in *InternalChronicleSpec) DeepCopyInto(out *InternalChronicleSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.AddEnv != nil {
 		in, out := &in.AddEnv, &out.AddEnv

--- a/client-go/applyconfiguration/core/v1beta1/chroniclespec.go
+++ b/client-go/applyconfiguration/core/v1beta1/chroniclespec.go
@@ -5,6 +5,10 @@
 
 package v1beta1
 
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
 // ChronicleSpecApplyConfiguration represents a declarative configuration of the ChronicleSpec type for use
 // with apply.
 type ChronicleSpecApplyConfiguration struct {
@@ -12,6 +16,7 @@ type ChronicleSpecApplyConfiguration struct {
 	Config               *ChronicleConfigApplyConfiguration `json:"config,omitempty"`
 	ImagePullSecrets     []string                           `json:"imagePullSecrets,omitempty"`
 	NodeSelector         map[string]string                  `json:"nodeSelector,omitempty"`
+	Resources            *v1.ResourceRequirements           `json:"resources,omitempty"`
 	AddEnv               map[string]string                  `json:"addEnv,omitempty"`
 	Image                *string                            `json:"image,omitempty"`
 	AwsAccountId         *string                            `json:"awsAccountId,omitempty"`
@@ -62,6 +67,14 @@ func (b *ChronicleSpecApplyConfiguration) WithNodeSelector(entries map[string]st
 	for k, v := range entries {
 		b.NodeSelector[k] = v
 	}
+	return b
+}
+
+// WithResources sets the Resources field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the value of the last call.
+func (b *ChronicleSpecApplyConfiguration) WithResources(value v1.ResourceRequirements) *ChronicleSpecApplyConfiguration {
+	b.Resources = &value
 	return b
 }
 

--- a/client-go/applyconfiguration/core/v1beta1/internalchroniclespec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalchroniclespec.go
@@ -12,14 +12,15 @@ import (
 // InternalChronicleSpecApplyConfiguration represents a declarative configuration of the InternalChronicleSpec type for use
 // with apply.
 type InternalChronicleSpecApplyConfiguration struct {
-	Enabled         *bool             `json:"enabled,omitempty"`
-	Teardown        *bool             `json:"teardown,omitempty"`
-	NodeSelector    map[string]string `json:"nodeSelector,omitempty"`
-	Image           *string           `json:"image,omitempty"`
-	AddEnv          map[string]string `json:"addEnv,omitempty"`
-	ImagePullPolicy *v1.PullPolicy    `json:"imagePullPolicy,omitempty"`
-	S3Bucket        *string           `json:"s3Bucket,omitempty"`
-	AgentImage      *string           `json:"agentImage,omitempty"`
+	Enabled         *bool                    `json:"enabled,omitempty"`
+	Teardown        *bool                    `json:"teardown,omitempty"`
+	NodeSelector    map[string]string        `json:"nodeSelector,omitempty"`
+	Resources       *v1.ResourceRequirements `json:"resources,omitempty"`
+	Image           *string                  `json:"image,omitempty"`
+	AddEnv          map[string]string        `json:"addEnv,omitempty"`
+	ImagePullPolicy *v1.PullPolicy           `json:"imagePullPolicy,omitempty"`
+	S3Bucket        *string                  `json:"s3Bucket,omitempty"`
+	AgentImage      *string                  `json:"agentImage,omitempty"`
 }
 
 // InternalChronicleSpecApplyConfiguration constructs a declarative configuration of the InternalChronicleSpec type for use with
@@ -55,6 +56,14 @@ func (b *InternalChronicleSpecApplyConfiguration) WithNodeSelector(entries map[s
 	for k, v := range entries {
 		b.NodeSelector[k] = v
 	}
+	return b
+}
+
+// WithResources sets the Resources field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the value of the last call.
+func (b *InternalChronicleSpecApplyConfiguration) WithResources(value v1.ResourceRequirements) *InternalChronicleSpecApplyConfiguration {
+	b.Resources = &value
 	return b
 }
 

--- a/config/crd/bases/core.posit.team_chronicles.yaml
+++ b/config/crd/bases/core.posit.team_chronicles.yaml
@@ -128,6 +128,67 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              resources:
+                description: |-
+                  Resources sets the chronicle-server container's resource requests/limits.
+                  If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               suspended:
                 description: |-
                   Suspended indicates Chronicle should not run serving resources (StatefulSet, Service)

--- a/config/crd/bases/core.posit.team_sites.yaml
+++ b/config/crd/bases/core.posit.team_sites.yaml
@@ -76,6 +76,67 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  resources:
+                    description: |-
+                      Resources sets the chronicle-server container's resource requests/limits.
+                      If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   s3Bucket:
                     type: string
                   teardown:

--- a/dist/chart/templates/crd/core.posit.team_chronicles.yaml
+++ b/dist/chart/templates/crd/core.posit.team_chronicles.yaml
@@ -149,6 +149,67 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              resources:
+                description: |-
+                  Resources sets the chronicle-server container's resource requests/limits.
+                  If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               suspended:
                 description: |-
                   Suspended indicates Chronicle should not run serving resources (StatefulSet, Service)

--- a/dist/chart/templates/crd/core.posit.team_sites.yaml
+++ b/dist/chart/templates/crd/core.posit.team_sites.yaml
@@ -97,6 +97,67 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  resources:
+                    description: |-
+                      Resources sets the chronicle-server container's resource requests/limits.
+                      If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   s3Bucket:
                     type: string
                   teardown:

--- a/internal/controller/core/chronicle_controller.go
+++ b/internal/controller/core/chronicle_controller.go
@@ -15,9 +15,11 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilptr "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +34,18 @@ type ChronicleReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 	Log    logr.Logger
+}
+
+// chronicleDefaultResources is the fallback resource requirements for the
+// chronicle-server container when the spec does not override them.
+var chronicleDefaultResources = corev1.ResourceRequirements{
+	Requests: corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+	},
+	Limits: corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("4Gi"),
+	},
 }
 
 //+kubebuilder:rbac:namespace=posit-team,groups=core.posit.team,resources=chronicles,verbs=get;list;watch;create;update;patch;delete
@@ -290,10 +304,7 @@ func (r *ChronicleReconciler) ensureDeployedService(ctx context.Context, req ctr
 								internal.DefaultPortChronicleHTTP.ContainerPort("http"),
 								internal.DefaultPortChronicleMetrics.ContainerPort("profile"),
 							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{},
-								Limits:   corev1.ResourceList{},
-							},
+							Resources: utilptr.Deref(c.Spec.Resources, chronicleDefaultResources),
 							VolumeMounts: product.ConcatLists(
 								[]corev1.VolumeMount{{
 									Name:      "config",

--- a/internal/controller/core/chronicle_controller_test.go
+++ b/internal/controller/core/chronicle_controller_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,4 +79,106 @@ func TestChronicleReconciler_Suspended(t *testing.T) {
 	require.NotNil(t, progressCond, "Progressing condition should be set when suspended")
 	assert.Equal(t, metav1.ConditionFalse, progressCond.Status)
 	assert.Equal(t, status.ReasonSuspended, progressCond.Reason)
+}
+
+// initChronicleReconciler creates a Chronicle reconciler backed by a fake client
+// and registers the given Chronicle so its resources can be reconciled.
+func initChronicleReconciler(t *testing.T, ctx context.Context, ns, name string, c *positcov1beta1.Chronicle) (context.Context, *ChronicleReconciler, ctrl.Request) {
+	t.Helper()
+
+	fakeEnv := localtest.FakeTestEnv{}
+	cli, scheme, log := fakeEnv.Start(loadSchemes)
+
+	r := &ChronicleReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log,
+	}
+
+	ctx = logr.NewContext(ctx, log)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	}
+
+	require.NoError(t, cli.Create(ctx, c))
+
+	return ctx, r, req
+}
+
+func newChronicle(ns, name string) *positcov1beta1.Chronicle {
+	return &positcov1beta1.Chronicle{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Chronicle",
+			APIVersion: "core.posit.team/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       positcov1beta1.ChronicleSpec{Image: "ghcr.io/rstudio/chronicle:test"},
+	}
+}
+
+func getChronicleContainerResources(t *testing.T, ctx context.Context, r *ChronicleReconciler, ns string, c *positcov1beta1.Chronicle) corev1.ResourceRequirements {
+	t.Helper()
+
+	sts := &appsv1.StatefulSet{}
+	require.NoError(t, r.Get(ctx, client.ObjectKey{Name: c.ComponentName(), Namespace: ns}, sts))
+	require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+	return sts.Spec.Template.Spec.Containers[0].Resources
+}
+
+// TestChronicleReconciler_DefaultResources verifies the chronicle-server container
+// gets the default resource requests plus a memory limit when Spec.Resources is unset.
+func TestChronicleReconciler_DefaultResources(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "chronicle-default-resources"
+
+	c := newChronicle(ns, name)
+	ctx, r, req := initChronicleReconciler(t, ctx, ns, name, c)
+
+	_, err := r.ensureDeployedService(ctx, req, c)
+	require.NoError(t, err)
+
+	resources := getChronicleContainerResources(t, ctx, r, ns, c)
+
+	assert.Equal(t, resource.MustParse("100m"), resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("1Gi"), resources.Requests[corev1.ResourceMemory])
+	// Chronicle deliberately sets a memory limit (unlike the main products) to
+	// contain runaway aggregation memory as a cgroup OOMKill, and no CPU limit.
+	assert.Equal(t, resource.MustParse("4Gi"), resources.Limits[corev1.ResourceMemory])
+	_, hasCPULimit := resources.Limits[corev1.ResourceCPU]
+	assert.False(t, hasCPULimit, "chronicle default resources should not set a CPU limit")
+}
+
+// TestChronicleReconciler_ResourcesOverride verifies an explicit Spec.Resources
+// override replaces the defaults entirely. This is how a site burns down a large
+// aggregation backlog with a higher bounded memory limit.
+func TestChronicleReconciler_ResourcesOverride(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "chronicle-resources-override"
+
+	override := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("56Gi"),
+		},
+	}
+
+	c := newChronicle(ns, name)
+	c.Spec.Resources = &override
+	ctx, r, req := initChronicleReconciler(t, ctx, ns, name, c)
+
+	_, err := r.ensureDeployedService(ctx, req, c)
+	require.NoError(t, err)
+
+	resources := getChronicleContainerResources(t, ctx, r, ns, c)
+
+	assert.Equal(t, resource.MustParse("1"), resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("8Gi"), resources.Requests[corev1.ResourceMemory])
+	assert.Equal(t, resource.MustParse("56Gi"), resources.Limits[corev1.ResourceMemory])
+	_, hasCPULimit := resources.Limits[corev1.ResourceCPU]
+	assert.False(t, hasCPULimit, "override with no CPU limit should not introduce one")
 }

--- a/internal/controller/core/site_controller_chronicle.go
+++ b/internal/controller/core/site_controller_chronicle.go
@@ -73,6 +73,7 @@ func (r *SiteReconciler) reconcileChronicle(ctx context.Context, req controllerr
 			},
 			ImagePullSecrets: site.Spec.ImagePullSecrets,
 			NodeSelector:     site.Spec.Chronicle.NodeSelector,
+			Resources:        site.Spec.Chronicle.Resources,
 			AddEnv:           site.Spec.Chronicle.AddEnv,
 			Image:            chronicleServerImage,
 		}

--- a/internal/crdapply/bases/core.posit.team_chronicles.yaml
+++ b/internal/crdapply/bases/core.posit.team_chronicles.yaml
@@ -128,6 +128,67 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              resources:
+                description: |-
+                  Resources sets the chronicle-server container's resource requests/limits.
+                  If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               suspended:
                 description: |-
                   Suspended indicates Chronicle should not run serving resources (StatefulSet, Service)

--- a/internal/crdapply/bases/core.posit.team_sites.yaml
+++ b/internal/crdapply/bases/core.posit.team_sites.yaml
@@ -76,6 +76,67 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  resources:
+                    description: |-
+                      Resources sets the chronicle-server container's resource requests/limits.
+                      If unset, product defaults are applied. Setting this replaces the defaults entirely.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   s3Bucket:
                     type: string
                   teardown:


### PR DESCRIPTION
## What

Adds an optional `resources` field to `ChronicleSpec` (surfaced through the
Site-level `InternalChronicleSpec`) that sets the `chronicle-server`
container's resource requests and limits.

- **Unset (default):** requests `cpu=100m` / `memory=1Gi`, limit `memory=4Gi`,
  no CPU limit.
- **Set:** the provided `ResourceRequirements` replaces the defaults entirely.

## Why

`chronicle-server` previously ran with empty requests and **no limits**. On a
high-ingest workload its refinement/aggregation memory can grow unbounded,
driving a **node-level OOM** that evicts chronicle and its neighbors, then
recurs on the next node. With `request=0` it is also the kubelet's first
eviction victim.

Giving the container a default memory limit converts a runaway into a
**contained cgroup OOMKill of chronicle alone** instead of a node-wide OOM.
The per-site override exists so deployments that legitimately need more
headroom can raise the ceiling rather than crashloop.

## Changes

- `api/core/v1beta1`: new `Resources *corev1.ResourceRequirements` on
  `ChronicleSpec` and `InternalChronicleSpec` (+ generated deepcopy).
- `client-go/applyconfiguration`: regenerated apply configs (`WithResources`).
- `internal/controller/core/chronicle_controller.go`: apply
  `Spec.Resources` to the container, falling back to a package-level default.
- `internal/controller/core/site_controller_chronicle.go`: thread
  `Spec.Chronicle.Resources` into the built `Chronicle`.
- CRDs regenerated in all three locations (`config/crd`, `dist/chart`,
  `internal/crdapply`).
- Tests: default-resources and override-resources cases for the reconciler.

## Testing

- [x] `make manifests generate` leaves the tree clean
- [x] `make test`
- [ ] Deployed via adhoc image to a test cluster; verified default + override
      land on the StatefulSet pod spec
