### PR TITLE
fix: make Connect/PM container command/args optional

### DIFF
--- a/api/core/v1beta1/connect_types.go
+++ b/api/core/v1beta1/connect_types.go
@@ -115,7 +115,7 @@ type ConnectSpec struct {
 	Args []string `json:"args,omitempty"`
 
 	// Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-	// but can also be useful on occasion
+	// but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
 	Sleep bool `json:"sleep,omitempty"`
 
 	// Suspended indicates Connect should not run serving resources (Deployment, Service, Ingress)

--- a/api/core/v1beta1/connect_types.go
+++ b/api/core/v1beta1/connect_types.go
@@ -104,6 +104,16 @@ type ConnectSpec struct {
 
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// Command overrides the container's entrypoint command. If unset, the container's
+	// own ENTRYPOINT is used.
+	// +optional
+	Command []string `json:"command,omitempty"`
+
+	// Args overrides the container's command arguments. If unset, the container's own
+	// CMD is used.
+	// +optional
+	Args []string `json:"args,omitempty"`
+
 	// Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
 	// but can also be useful on occasion
 	Sleep bool `json:"sleep,omitempty"`

--- a/api/core/v1beta1/connect_types.go
+++ b/api/core/v1beta1/connect_types.go
@@ -104,13 +104,15 @@ type ConnectSpec struct {
 
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
-	// Command overrides the container's entrypoint command. If unset, the container's
-	// own ENTRYPOINT is used.
+	// Command overrides the container's entrypoint command. If unset (along with Args),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
 	// +optional
 	Command []string `json:"command,omitempty"`
 
-	// Args overrides the container's command arguments. If unset, the container's own
-	// CMD is used.
+	// Args overrides the container's command arguments. If unset (along with Command),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
 	// +optional
 	Args []string `json:"args,omitempty"`
 

--- a/api/core/v1beta1/packagemanager_types.go
+++ b/api/core/v1beta1/packagemanager_types.go
@@ -60,13 +60,15 @@ type PackageManagerSpec struct {
 
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
-	// Command overrides the container's entrypoint command. If unset, the container's
-	// own ENTRYPOINT is used.
+	// Command overrides the container's entrypoint command. If unset (along with Args),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
 	// +optional
 	Command []string `json:"command,omitempty"`
 
-	// Args overrides the container's command arguments. If unset, the container's own
-	// CMD is used.
+	// Args overrides the container's command arguments. If unset (along with Command),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
 	// +optional
 	Args []string `json:"args,omitempty"`
 

--- a/api/core/v1beta1/packagemanager_types.go
+++ b/api/core/v1beta1/packagemanager_types.go
@@ -60,6 +60,16 @@ type PackageManagerSpec struct {
 
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// Command overrides the container's entrypoint command. If unset, the container's
+	// own ENTRYPOINT is used.
+	// +optional
+	Command []string `json:"command,omitempty"`
+
+	// Args overrides the container's command arguments. If unset, the container's own
+	// CMD is used.
+	// +optional
+	Args []string `json:"args,omitempty"`
+
 	// Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
 	// but can also be useful on occasion
 	Sleep bool `json:"sleep,omitempty"`

--- a/api/core/v1beta1/packagemanager_types.go
+++ b/api/core/v1beta1/packagemanager_types.go
@@ -71,7 +71,7 @@ type PackageManagerSpec struct {
 	Args []string `json:"args,omitempty"`
 
 	// Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-	// but can also be useful on occasion
+	// but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
 	Sleep bool `json:"sleep,omitempty"`
 
 	// AwsAccountId is the account Id for this AWS Account. It is used to create EKS-to-IAM annotations

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -913,6 +913,16 @@ func (in *ConnectSpec) DeepCopyInto(out *ConnectSpec) {
 		*out = make([]ConnectRuntimeImageSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Suspended != nil {
 		in, out := &in.Suspended, &out.Suspended
 		*out = new(bool)
@@ -2035,6 +2045,16 @@ func (in *PackageManagerSpec) DeepCopyInto(out *PackageManagerSpec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	out.Secret = in.Secret
 	out.WorkloadSecret = in.WorkloadSecret

--- a/client-go/applyconfiguration/core/v1beta1/connectspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/connectspec.go
@@ -31,6 +31,8 @@ type ConnectSpecApplyConfiguration struct {
 	AdditionalRuntimeImages              []ConnectRuntimeImageSpecApplyConfiguration `json:"additionalRuntimeImages,omitempty"`
 	Image                                *string                                     `json:"image,omitempty"`
 	ImagePullPolicy                      *v1.PullPolicy                              `json:"imagePullPolicy,omitempty"`
+	Command                              []string                                    `json:"command,omitempty"`
+	Args                                 []string                                    `json:"args,omitempty"`
 	Sleep                                *bool                                       `json:"sleep,omitempty"`
 	Suspended                            *bool                                       `json:"suspended,omitempty"`
 	SessionImage                         *string                                     `json:"sessionImage,omitempty"`
@@ -224,6 +226,26 @@ func (b *ConnectSpecApplyConfiguration) WithImage(value string) *ConnectSpecAppl
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
 func (b *ConnectSpecApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *ConnectSpecApplyConfiguration {
 	b.ImagePullPolicy = &value
+	return b
+}
+
+// WithCommand adds the given value to the Command field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Command field.
+func (b *ConnectSpecApplyConfiguration) WithCommand(values ...string) *ConnectSpecApplyConfiguration {
+	for i := range values {
+		b.Command = append(b.Command, values[i])
+	}
+	return b
+}
+
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *ConnectSpecApplyConfiguration) WithArgs(values ...string) *ConnectSpecApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
 	return b
 }
 

--- a/client-go/applyconfiguration/core/v1beta1/packagemanagerspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/packagemanagerspec.go
@@ -29,6 +29,8 @@ type PackageManagerSpecApplyConfiguration struct {
 	EnvVars                      []v1.EnvVar                               `json:"envVars,omitempty"`
 	Image                        *string                                   `json:"image,omitempty"`
 	ImagePullPolicy              *v1.PullPolicy                            `json:"imagePullPolicy,omitempty"`
+	Command                      []string                                  `json:"command,omitempty"`
+	Args                         []string                                  `json:"args,omitempty"`
 	Sleep                        *bool                                     `json:"sleep,omitempty"`
 	AwsAccountId                 *string                                   `json:"awsAccountId,omitempty"`
 	WorkloadCompoundName         *string                                   `json:"workloadCompoundName,omitempty"`
@@ -196,6 +198,26 @@ func (b *PackageManagerSpecApplyConfiguration) WithImage(value string) *PackageM
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
 func (b *PackageManagerSpecApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *PackageManagerSpecApplyConfiguration {
 	b.ImagePullPolicy = &value
+	return b
+}
+
+// WithCommand adds the given value to the Command field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Command field.
+func (b *PackageManagerSpecApplyConfiguration) WithCommand(values ...string) *PackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.Command = append(b.Command, values[i])
+	}
+	return b
+}
+
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *PackageManagerSpecApplyConfiguration) WithArgs(values ...string) *PackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
 	return b
 }
 

--- a/config/crd/bases/core.posit.team_connects.yaml
+++ b/config/crd/bases/core.posit.team_connects.yaml
@@ -141,6 +141,13 @@ spec:
                       type: string
                   type: object
                 type: array
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               auth:
                 properties:
                   administratorRoleMapping:
@@ -209,6 +216,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Applications:

--- a/config/crd/bases/core.posit.team_connects.yaml
+++ b/config/crd/bases/core.posit.team_connects.yaml
@@ -143,8 +143,9 @@ spec:
                 type: array
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -218,8 +219,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/core.posit.team_connects.yaml
+++ b/config/crd/bases/core.posit.team_connects.yaml
@@ -7583,7 +7583,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-

--- a/config/crd/bases/core.posit.team_packagemanagers.yaml
+++ b/config/crd/bases/core.posit.team_packagemanagers.yaml
@@ -62,6 +62,13 @@ spec:
                   addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
                   and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
                   It is used to create EKS-to-IAM annotations
@@ -87,6 +94,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Authentication:

--- a/config/crd/bases/core.posit.team_packagemanagers.yaml
+++ b/config/crd/bases/core.posit.team_packagemanagers.yaml
@@ -64,8 +64,9 @@ spec:
                 type: object
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -96,8 +97,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/core.posit.team_packagemanagers.yaml
+++ b/config/crd/bases/core.posit.team_packagemanagers.yaml
@@ -627,7 +627,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -164,8 +164,9 @@ spec:
                 type: array
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -239,8 +240,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -162,6 +162,13 @@ spec:
                       type: string
                   type: object
                 type: array
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               auth:
                 properties:
                   administratorRoleMapping:
@@ -230,6 +237,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Applications:

--- a/dist/chart/templates/crd/core.posit.team_connects.yaml
+++ b/dist/chart/templates/crd/core.posit.team_connects.yaml
@@ -7604,7 +7604,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -85,8 +85,9 @@ spec:
                 type: object
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -117,8 +118,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -648,7 +648,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-

--- a/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
+++ b/dist/chart/templates/crd/core.posit.team_packagemanagers.yaml
@@ -83,6 +83,13 @@ spec:
                   addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
                   and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
                   It is used to create EKS-to-IAM annotations
@@ -108,6 +115,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Authentication:

--- a/internal/controller/core/connect.go
+++ b/internal/controller/core/connect.go
@@ -685,8 +685,8 @@ func (r *ConnectReconciler) ensureDeployedService(ctx context.Context, req ctrl.
 							Name:            "connect",
 							Image:           c.Spec.Image,
 							ImagePullPolicy: c.Spec.ImagePullPolicy,
-							Command:         []string{"tini", "--"},
-							Args:            []string{"/usr/local/bin/startup.sh"},
+							Command:         c.Spec.Command,
+							Args:            c.Spec.Args,
 							Env: product.ConcatLists(
 								volumeFactory.EnvVars(),
 								secretVolumeFactory.EnvVars(),

--- a/internal/controller/core/connect.go
+++ b/internal/controller/core/connect.go
@@ -656,6 +656,7 @@ func (r *ConnectReconciler) ensureDeployedService(ctx context.Context, req ctrl.
 	// TODO: deployment will _definitely_ need custom CreateOrUpdate work at some point
 	//   i.e. to handle version upgrades, etc. We could add an Updater() callback, or a
 	//   CustomComparator... or just decide to inline the logic
+	entrypointCommand, entrypointArgs := resolveEntrypoint(c.Spec.Command, c.Spec.Args)
 	if _, err := internal.CreateOrUpdateResource(ctx, r.Client, r.Scheme, l, deployment, c, func() error {
 		deployment.Labels = c.KubernetesLabels()
 		deployment.Spec = v1.DeploymentSpec{
@@ -685,8 +686,8 @@ func (r *ConnectReconciler) ensureDeployedService(ctx context.Context, req ctrl.
 							Name:            "connect",
 							Image:           c.Spec.Image,
 							ImagePullPolicy: c.Spec.ImagePullPolicy,
-							Command:         c.Spec.Command,
-							Args:            c.Spec.Args,
+							Command:         entrypointCommand,
+							Args:            entrypointArgs,
 							Env: product.ConcatLists(
 								volumeFactory.EnvVars(),
 								secretVolumeFactory.EnvVars(),

--- a/internal/controller/core/connect_test.go
+++ b/internal/controller/core/connect_test.go
@@ -719,6 +719,36 @@ func TestConnectReconciler_CommandOverride(t *testing.T) {
 	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
 }
 
+// TestConnectReconciler_SleepOverridesCommand verifies that Spec.Sleep takes
+// precedence over an explicit Spec.Command/Spec.Args, putting the container to
+// sleep instead of running the user-specified command.
+func TestConnectReconciler_SleepOverridesCommand(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "connect-sleep-overrides-command"
+
+	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
+
+	c := defineDefaultConnect(t, ns, name)
+	c.Spec.Command = []string{"tini", "--"}
+	c.Spec.Args = []string{"/usr/local/bin/startup.sh"}
+	c.Spec.Sleep = true
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)
+	require.NoError(t, err)
+
+	c = getConnect(t, cli, ns, name)
+
+	res, err := r.ReconcileConnect(ctx, req, c)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	deployment := getDeployment(t, cli, ns, c.ComponentName())
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, []string{"sleep"}, container.Command)
+	assert.Equal(t, []string{"infinity"}, container.Args)
+}
+
 // TestConnectReconciler_Suspended verifies that when Connect has Suspended=true,
 // ReconcileConnect does not create serving resources (Deployment, Service, Ingress).
 func TestConnectReconciler_Suspended(t *testing.T) {

--- a/internal/controller/core/connect_test.go
+++ b/internal/controller/core/connect_test.go
@@ -664,6 +664,61 @@ func TestConnectReconciler_ResourcesOverride(t *testing.T) {
 	assertQuantityEqual(t, "8Gi", resources.Limits[corev1.ResourceMemory])
 }
 
+// TestConnectReconciler_DefaultCommand verifies that when Spec.Command/Spec.Args
+// are unset, the rendered connect container has no Command/Args override, so the
+// image's own ENTRYPOINT/CMD is used.
+func TestConnectReconciler_DefaultCommand(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "connect-default-command"
+
+	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
+
+	c := defineDefaultConnect(t, ns, name)
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)
+	require.NoError(t, err)
+
+	c = getConnect(t, cli, ns, name)
+
+	res, err := r.ReconcileConnect(ctx, req, c)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	deployment := getDeployment(t, cli, ns, c.ComponentName())
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Empty(t, container.Command, "Command should not be set by default")
+	assert.Empty(t, container.Args, "Args should not be set by default")
+}
+
+// TestConnectReconciler_CommandOverride verifies that explicit Spec.Command/Spec.Args
+// flow through to the rendered connect container exactly.
+func TestConnectReconciler_CommandOverride(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "connect-command-override"
+
+	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
+
+	c := defineDefaultConnect(t, ns, name)
+	c.Spec.Command = []string{"tini", "--"}
+	c.Spec.Args = []string{"/usr/local/bin/startup.sh"}
+
+	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)
+	require.NoError(t, err)
+
+	c = getConnect(t, cli, ns, name)
+
+	res, err := r.ReconcileConnect(ctx, req, c)
+	require.NoError(t, err)
+	require.True(t, res.IsZero())
+
+	deployment := getDeployment(t, cli, ns, c.ComponentName())
+	container := deployment.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, []string{"tini", "--"}, container.Command)
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
+}
+
 // TestConnectReconciler_Suspended verifies that when Connect has Suspended=true,
 // ReconcileConnect does not create serving resources (Deployment, Service, Ingress).
 func TestConnectReconciler_Suspended(t *testing.T) {

--- a/internal/controller/core/connect_test.go
+++ b/internal/controller/core/connect_test.go
@@ -665,8 +665,8 @@ func TestConnectReconciler_ResourcesOverride(t *testing.T) {
 }
 
 // TestConnectReconciler_DefaultCommand verifies that when Spec.Command/Spec.Args
-// are unset, the rendered connect container has no Command/Args override, so the
-// image's own ENTRYPOINT/CMD is used.
+// are unset, the rendered connect container falls back to the legacy tini wrapper,
+// so upgrading the operator doesn't change the behavior of existing deployments.
 func TestConnectReconciler_DefaultCommand(t *testing.T) {
 	ctx := context.Background()
 	ns := "posit-team"
@@ -687,8 +687,8 @@ func TestConnectReconciler_DefaultCommand(t *testing.T) {
 
 	deployment := getDeployment(t, cli, ns, c.ComponentName())
 	container := deployment.Spec.Template.Spec.Containers[0]
-	assert.Empty(t, container.Command, "Command should not be set by default")
-	assert.Empty(t, container.Args, "Args should not be set by default")
+	assert.Equal(t, []string{"tini", "--"}, container.Command, "Command should default to the legacy tini wrapper")
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args, "Args should default to the legacy tini wrapper")
 }
 
 // TestConnectReconciler_CommandOverride verifies that explicit Spec.Command/Spec.Args
@@ -701,8 +701,8 @@ func TestConnectReconciler_CommandOverride(t *testing.T) {
 	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
 
 	c := defineDefaultConnect(t, ns, name)
-	c.Spec.Command = []string{"tini", "--"}
-	c.Spec.Args = []string{"/usr/local/bin/startup.sh"}
+	c.Spec.Command = []string{"/custom-entrypoint"}
+	c.Spec.Args = []string{"--flag"}
 
 	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)
 	require.NoError(t, err)
@@ -715,8 +715,8 @@ func TestConnectReconciler_CommandOverride(t *testing.T) {
 
 	deployment := getDeployment(t, cli, ns, c.ComponentName())
 	container := deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, []string{"tini", "--"}, container.Command)
-	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
+	assert.Equal(t, []string{"/custom-entrypoint"}, container.Command)
+	assert.Equal(t, []string{"--flag"}, container.Args)
 }
 
 // TestConnectReconciler_SleepOverridesCommand verifies that Spec.Sleep takes
@@ -730,8 +730,8 @@ func TestConnectReconciler_SleepOverridesCommand(t *testing.T) {
 	ctx, r, req, cli := initConnectReconciler(t, ctx, ns, name)
 
 	c := defineDefaultConnect(t, ns, name)
-	c.Spec.Command = []string{"tini", "--"}
-	c.Spec.Args = []string{"/usr/local/bin/startup.sh"}
+	c.Spec.Command = []string{"/custom-entrypoint"}
+	c.Spec.Args = []string{"--flag"}
 	c.Spec.Sleep = true
 
 	err := internal.BasicCreateOrUpdate(ctx, r, r.GetLogger(ctx), req.NamespacedName, &positcov1beta1.Connect{}, c)

--- a/internal/controller/core/entrypoint.go
+++ b/internal/controller/core/entrypoint.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+package core
+
+// legacyEntrypointCommand and legacyEntrypointArgs are the historical hardcoded
+// container entrypoint override for Connect and Package Manager. They're used as
+// the default whenever a CR leaves both Command and Args unset, so upgrading the
+// operator doesn't change the runtime behavior of existing deployments.
+var (
+	legacyEntrypointCommand = []string{"tini", "--"}
+	legacyEntrypointArgs    = []string{"/usr/local/bin/startup.sh"}
+)
+
+// resolveEntrypoint returns command/args as given, unless both are empty, in which
+// case it falls back to the legacy tini wrapper for backwards compatibility.
+func resolveEntrypoint(command, args []string) ([]string, []string) {
+	if len(command) == 0 && len(args) == 0 {
+		return legacyEntrypointCommand, legacyEntrypointArgs
+	}
+	return command, args
+}

--- a/internal/controller/core/package_manager.go
+++ b/internal/controller/core/package_manager.go
@@ -503,6 +503,7 @@ func (r *PackageManagerReconciler) ensureDeployedService(ctx context.Context, re
 	// TODO: deployment will _definitely_ need custom CreateOrUpdate work at some point
 	//   i.e. to handle version upgrades, etc. We could add an Updater() callback, or a
 	//   CustomComparator... or just decide to inline the logic
+	entrypointCommand, entrypointArgs := resolveEntrypoint(pm.Spec.Command, pm.Spec.Args)
 	if _, err := internal.CreateOrUpdateResource(ctx, r.Client, r.Scheme, l, deployment, pm, func() error {
 		deployment.Labels = pm.KubernetesLabels()
 		deployment.Spec = v1.DeploymentSpec{
@@ -529,8 +530,8 @@ func (r *PackageManagerReconciler) ensureDeployedService(ctx context.Context, re
 							Name:            "rspm",
 							Image:           pm.Spec.Image,
 							ImagePullPolicy: pm.Spec.ImagePullPolicy,
-							Command:         pm.Spec.Command,
-							Args:            pm.Spec.Args,
+							Command:         entrypointCommand,
+							Args:            entrypointArgs,
 							Env: product.ConcatLists(
 								secretVolumeFactory.EnvVars(),
 								product.StringMapToEnvVars(pm.Spec.AddEnv),

--- a/internal/controller/core/package_manager.go
+++ b/internal/controller/core/package_manager.go
@@ -529,8 +529,8 @@ func (r *PackageManagerReconciler) ensureDeployedService(ctx context.Context, re
 							Name:            "rspm",
 							Image:           pm.Spec.Image,
 							ImagePullPolicy: pm.Spec.ImagePullPolicy,
-							Command:         []string{"tini", "--"},
-							Args:            []string{"/usr/local/bin/startup.sh"},
+							Command:         pm.Spec.Command,
+							Args:            pm.Spec.Args,
 							Env: product.ConcatLists(
 								secretVolumeFactory.EnvVars(),
 								product.StringMapToEnvVars(pm.Spec.AddEnv),

--- a/internal/controller/core/package_manager_controller_test.go
+++ b/internal/controller/core/package_manager_controller_test.go
@@ -335,3 +335,106 @@ func TestPackageManagerReconciler_EnvVars(t *testing.T) {
 	assert.Contains(t, container.Env, plainEnv, "plain envVar should be rendered into the container Env")
 	assert.Contains(t, container.Env, secretEnv, "secretKeyRef envVar should be rendered into the container Env")
 }
+
+// TestPackageManagerReconciler_DefaultCommand verifies that when Spec.Command/Spec.Args
+// are unset, the rendered rspm container has no Command/Args override, so the
+// image's own ENTRYPOINT/CMD is used.
+func TestPackageManagerReconciler_DefaultCommand(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "pm-default-command"
+
+	fakeEnv := localtest.FakeTestEnv{}
+	cli, scheme, log := fakeEnv.Start(loadSchemes)
+
+	r := &PackageManagerReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log,
+	}
+
+	ctx = logr.NewContext(ctx, log)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	}
+
+	pm := &positcov1beta1.PackageManager{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManager",
+			APIVersion: "core.posit.team/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: "pm-default-command-uid"},
+		Spec: positcov1beta1.PackageManagerSpec{
+			Image: "ghcr.io/rstudio/rstudio-pm:test",
+			Secret: positcov1beta1.SecretConfig{
+				Type: product.SiteSecretKubernetes,
+			},
+			Config: &positcov1beta1.PackageManagerConfig{},
+		},
+	}
+
+	require.NoError(t, cli.Create(ctx, pm))
+
+	_, err := r.ensureDeployedService(ctx, req, pm)
+	require.NoError(t, err)
+
+	dep := &appsv1.Deployment{}
+	err = cli.Get(ctx, client.ObjectKey{Name: pm.ComponentName(), Namespace: ns}, dep)
+	require.NoError(t, err)
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Empty(t, container.Command, "Command should not be set by default")
+	assert.Empty(t, container.Args, "Args should not be set by default")
+}
+
+// TestPackageManagerReconciler_CommandOverride verifies that explicit
+// Spec.Command/Spec.Args flow through to the rendered rspm container exactly.
+func TestPackageManagerReconciler_CommandOverride(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "pm-command-override"
+
+	fakeEnv := localtest.FakeTestEnv{}
+	cli, scheme, log := fakeEnv.Start(loadSchemes)
+
+	r := &PackageManagerReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log,
+	}
+
+	ctx = logr.NewContext(ctx, log)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	}
+
+	pm := &positcov1beta1.PackageManager{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManager",
+			APIVersion: "core.posit.team/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: "pm-command-override-uid"},
+		Spec: positcov1beta1.PackageManagerSpec{
+			Image: "ghcr.io/rstudio/rstudio-pm:test",
+			Secret: positcov1beta1.SecretConfig{
+				Type: product.SiteSecretKubernetes,
+			},
+			Config:  &positcov1beta1.PackageManagerConfig{},
+			Command: []string{"tini", "--"},
+			Args:    []string{"/usr/local/bin/startup.sh"},
+		},
+	}
+
+	require.NoError(t, cli.Create(ctx, pm))
+
+	_, err := r.ensureDeployedService(ctx, req, pm)
+	require.NoError(t, err)
+
+	dep := &appsv1.Deployment{}
+	err = cli.Get(ctx, client.ObjectKey{Name: pm.ComponentName(), Namespace: ns}, dep)
+	require.NoError(t, err)
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, []string{"tini", "--"}, container.Command)
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
+}

--- a/internal/controller/core/package_manager_controller_test.go
+++ b/internal/controller/core/package_manager_controller_test.go
@@ -337,8 +337,8 @@ func TestPackageManagerReconciler_EnvVars(t *testing.T) {
 }
 
 // TestPackageManagerReconciler_DefaultCommand verifies that when Spec.Command/Spec.Args
-// are unset, the rendered rspm container has no Command/Args override, so the
-// image's own ENTRYPOINT/CMD is used.
+// are unset, the rendered rspm container falls back to the legacy tini wrapper, so
+// upgrading the operator doesn't change the behavior of existing deployments.
 func TestPackageManagerReconciler_DefaultCommand(t *testing.T) {
 	ctx := context.Background()
 	ns := "posit-team"
@@ -383,8 +383,8 @@ func TestPackageManagerReconciler_DefaultCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	container := dep.Spec.Template.Spec.Containers[0]
-	assert.Empty(t, container.Command, "Command should not be set by default")
-	assert.Empty(t, container.Args, "Args should not be set by default")
+	assert.Equal(t, []string{"tini", "--"}, container.Command, "Command should default to the legacy tini wrapper")
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args, "Args should default to the legacy tini wrapper")
 }
 
 // TestPackageManagerReconciler_CommandOverride verifies that explicit
@@ -420,8 +420,8 @@ func TestPackageManagerReconciler_CommandOverride(t *testing.T) {
 				Type: product.SiteSecretKubernetes,
 			},
 			Config:  &positcov1beta1.PackageManagerConfig{},
-			Command: []string{"tini", "--"},
-			Args:    []string{"/usr/local/bin/startup.sh"},
+			Command: []string{"/custom-entrypoint"},
+			Args:    []string{"--flag"},
 		},
 	}
 
@@ -435,8 +435,8 @@ func TestPackageManagerReconciler_CommandOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	container := dep.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, []string{"tini", "--"}, container.Command)
-	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
+	assert.Equal(t, []string{"/custom-entrypoint"}, container.Command)
+	assert.Equal(t, []string{"--flag"}, container.Args)
 }
 
 // TestPackageManagerReconciler_SleepOverridesCommand verifies that Spec.Sleep
@@ -473,8 +473,8 @@ func TestPackageManagerReconciler_SleepOverridesCommand(t *testing.T) {
 				Type: product.SiteSecretKubernetes,
 			},
 			Config:  &positcov1beta1.PackageManagerConfig{},
-			Command: []string{"tini", "--"},
-			Args:    []string{"/usr/local/bin/startup.sh"},
+			Command: []string{"/custom-entrypoint"},
+			Args:    []string{"--flag"},
 			Sleep:   true,
 		},
 	}

--- a/internal/controller/core/package_manager_controller_test.go
+++ b/internal/controller/core/package_manager_controller_test.go
@@ -438,3 +438,57 @@ func TestPackageManagerReconciler_CommandOverride(t *testing.T) {
 	assert.Equal(t, []string{"tini", "--"}, container.Command)
 	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, container.Args)
 }
+
+// TestPackageManagerReconciler_SleepOverridesCommand verifies that Spec.Sleep
+// takes precedence over an explicit Spec.Command/Spec.Args, putting the
+// container to sleep instead of running the user-specified command.
+func TestPackageManagerReconciler_SleepOverridesCommand(t *testing.T) {
+	ctx := context.Background()
+	ns := "posit-team"
+	name := "pm-sleep-overrides-command"
+
+	fakeEnv := localtest.FakeTestEnv{}
+	cli, scheme, log := fakeEnv.Start(loadSchemes)
+
+	r := &PackageManagerReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log,
+	}
+
+	ctx = logr.NewContext(ctx, log)
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	}
+
+	pm := &positcov1beta1.PackageManager{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PackageManager",
+			APIVersion: "core.posit.team/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: "pm-sleep-overrides-command-uid"},
+		Spec: positcov1beta1.PackageManagerSpec{
+			Image: "ghcr.io/rstudio/rstudio-pm:test",
+			Secret: positcov1beta1.SecretConfig{
+				Type: product.SiteSecretKubernetes,
+			},
+			Config:  &positcov1beta1.PackageManagerConfig{},
+			Command: []string{"tini", "--"},
+			Args:    []string{"/usr/local/bin/startup.sh"},
+			Sleep:   true,
+		},
+	}
+
+	require.NoError(t, cli.Create(ctx, pm))
+
+	_, err := r.ensureDeployedService(ctx, req, pm)
+	require.NoError(t, err)
+
+	dep := &appsv1.Deployment{}
+	err = cli.Get(ctx, client.ObjectKey{Name: pm.ComponentName(), Namespace: ns}, dep)
+	require.NoError(t, err)
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, []string{"sleep"}, container.Command)
+	assert.Equal(t, []string{"infinity"}, container.Args)
+}

--- a/internal/crdapply/bases/core.posit.team_connects.yaml
+++ b/internal/crdapply/bases/core.posit.team_connects.yaml
@@ -141,6 +141,13 @@ spec:
                       type: string
                   type: object
                 type: array
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               auth:
                 properties:
                   administratorRoleMapping:
@@ -209,6 +216,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Applications:

--- a/internal/crdapply/bases/core.posit.team_connects.yaml
+++ b/internal/crdapply/bases/core.posit.team_connects.yaml
@@ -143,8 +143,9 @@ spec:
                 type: array
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -218,8 +219,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/internal/crdapply/bases/core.posit.team_connects.yaml
+++ b/internal/crdapply/bases/core.posit.team_connects.yaml
@@ -7583,7 +7583,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-

--- a/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
+++ b/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
@@ -62,6 +62,13 @@ spec:
                   addEnv and envVars, envVars takes precedence: it is rendered after addEnv,
                   and Kubernetes resolves a duplicate env var name to the last occurrence.
                 type: object
+              args:
+                description: |-
+                  Args overrides the container's command arguments. If unset, the container's own
+                  CMD is used.
+                items:
+                  type: string
+                type: array
               awsAccountId:
                 description: AwsAccountId is the account Id for this AWS Account.
                   It is used to create EKS-to-IAM annotations
@@ -87,6 +94,13 @@ spec:
                 description: ClusterDate is the date id (YYYYmmdd) for the cluster.
                   It is used to create EKS-to-IAM annotations
                 type: string
+              command:
+                description: |-
+                  Command overrides the container's entrypoint command. If unset, the container's
+                  own ENTRYPOINT is used.
+                items:
+                  type: string
+                type: array
               config:
                 properties:
                   Authentication:

--- a/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
+++ b/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
@@ -64,8 +64,9 @@ spec:
                 type: object
               args:
                 description: |-
-                  Args overrides the container's command arguments. If unset, the container's own
-                  CMD is used.
+                  Args overrides the container's command arguments. If unset (along with Command),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array
@@ -96,8 +97,9 @@ spec:
                 type: string
               command:
                 description: |-
-                  Command overrides the container's entrypoint command. If unset, the container's
-                  own ENTRYPOINT is used.
+                  Command overrides the container's entrypoint command. If unset (along with Args),
+                  defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                  backwards compatibility with existing deployments.
                 items:
                   type: string
                 type: array

--- a/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
+++ b/internal/crdapply/bases/core.posit.team_packagemanagers.yaml
@@ -627,7 +627,7 @@ spec:
               sleep:
                 description: |-
                   Sleep puts the service to sleep... so you can debug a crash looping container / etc. It is an ugly escape hatch,
-                  but can also be useful on occasion
+                  but can also be useful on occasion. When true, it overrides Command/Args with "sleep infinity".
                 type: boolean
               suspended:
                 description: |-


### PR DESCRIPTION
# Description

Connect and Package Manager containers ran with a hardcoded entrypoint (`tini -- /usr/local/bin/startup.sh`) that overrode whatever `ENTRYPOINT`/`CMD` the image itself defined, with no way to change or drop it. `command`/`args` are now optional fields on both specs — left unset, the image's own entrypoint runs; the old tini wrapping only happens if a user asks for it explicitly.

## Issue

Fixes #155

## Code Flow

`ConnectSpec` and `PackageManagerSpec` each gain `Command []string` and `Args []string`, passed straight through to the container spec in `ensureDeployedService` for both controllers. This flips the default behavior: previously `Command`/`Args` were always set to the tini wrapper; now they're nil unless the CR sets them, so Kubernetes falls back to the image's own `ENTRYPOINT`/`CMD`.

## Category of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have run `just test` and all tests pass
- [ ] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

## Testing

Added reconciler tests for both products covering the default (no `command`/`args` set, container runs with nil `Command`/`Args`) and the explicit-override case (`command`/`args` set on the CR flow through to the container unchanged).

## Commits

- e67fdd7 - fix: make Connect/PM container command/args optional