### PR TITLE
fix: propagate Connect/PM command/args overrides through Site CR

### DIFF
--- a/api/core/v1beta1/site_types.go
+++ b/api/core/v1beta1/site_types.go
@@ -228,6 +228,18 @@ type InternalPackageManagerSpec struct {
 
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// Command overrides the container's entrypoint command. If unset (along with Args),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
+	// +optional
+	Command []string `json:"command,omitempty"`
+
+	// Args overrides the container's command arguments. If unset (along with Command),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
+	// +optional
+	Args []string `json:"args,omitempty"`
+
 	S3Bucket string `json:"s3Bucket,omitempty"`
 
 	Replicas int `json:"replicas,omitempty"`
@@ -306,6 +318,18 @@ type InternalConnectSpec struct {
 	SessionImage string `json:"sessionImage,omitempty"`
 
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
+	// Command overrides the container's entrypoint command. If unset (along with Args),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
+	// +optional
+	Command []string `json:"command,omitempty"`
+
+	// Args overrides the container's command arguments. If unset (along with Command),
+	// defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+	// backwards compatibility with existing deployments.
+	// +optional
+	Args []string `json:"args,omitempty"`
 
 	Databricks *DatabricksConfig `json:"databricks,omitempty"`
 

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -1272,6 +1272,16 @@ func (in *InternalConnectSpec) DeepCopyInto(out *InternalConnectSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Databricks != nil {
 		in, out := &in.Databricks, &out.Databricks
 		*out = new(DatabricksConfig)
@@ -1396,6 +1406,16 @@ func (in *InternalPackageManagerSpec) DeepCopyInto(out *InternalPackageManagerSp
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.GitSSHKeys != nil {
 		in, out := &in.GitSSHKeys, &out.GitSSHKeys

--- a/client-go/applyconfiguration/core/v1beta1/internalconnectspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalconnectspec.go
@@ -26,6 +26,8 @@ type InternalConnectSpecApplyConfiguration struct {
 	Image                   *string                                                `json:"image,omitempty"`
 	SessionImage            *string                                                `json:"sessionImage,omitempty"`
 	ImagePullPolicy         *v1.PullPolicy                                         `json:"imagePullPolicy,omitempty"`
+	Command                 []string                                               `json:"command,omitempty"`
+	Args                    []string                                               `json:"args,omitempty"`
 	Databricks              *DatabricksConfigApplyConfiguration                    `json:"databricks,omitempty"`
 	LoggedInWarning         *string                                                `json:"loggedInWarning,omitempty"`
 	PublicWarning           *string                                                `json:"publicWarning,omitempty"`
@@ -161,6 +163,26 @@ func (b *InternalConnectSpecApplyConfiguration) WithSessionImage(value string) *
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
 func (b *InternalConnectSpecApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *InternalConnectSpecApplyConfiguration {
 	b.ImagePullPolicy = &value
+	return b
+}
+
+// WithCommand adds the given value to the Command field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Command field.
+func (b *InternalConnectSpecApplyConfiguration) WithCommand(values ...string) *InternalConnectSpecApplyConfiguration {
+	for i := range values {
+		b.Command = append(b.Command, values[i])
+	}
+	return b
+}
+
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *InternalConnectSpecApplyConfiguration) WithArgs(values ...string) *InternalConnectSpecApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
 	return b
 }
 

--- a/client-go/applyconfiguration/core/v1beta1/internalpackagemanagerspec.go
+++ b/client-go/applyconfiguration/core/v1beta1/internalpackagemanagerspec.go
@@ -23,6 +23,8 @@ type InternalPackageManagerSpecApplyConfiguration struct {
 	EnvVars             []v1.EnvVar                         `json:"envVars,omitempty"`
 	Image               *string                             `json:"image,omitempty"`
 	ImagePullPolicy     *v1.PullPolicy                      `json:"imagePullPolicy,omitempty"`
+	Command             []string                            `json:"command,omitempty"`
+	Args                []string                            `json:"args,omitempty"`
 	S3Bucket            *string                             `json:"s3Bucket,omitempty"`
 	Replicas            *int                                `json:"replicas,omitempty"`
 	DomainPrefix        *string                             `json:"domainPrefix,omitempty"`
@@ -131,6 +133,26 @@ func (b *InternalPackageManagerSpecApplyConfiguration) WithImage(value string) *
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
 func (b *InternalPackageManagerSpecApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *InternalPackageManagerSpecApplyConfiguration {
 	b.ImagePullPolicy = &value
+	return b
+}
+
+// WithCommand adds the given value to the Command field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Command field.
+func (b *InternalPackageManagerSpecApplyConfiguration) WithCommand(values ...string) *InternalPackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.Command = append(b.Command, values[i])
+	}
+	return b
+}
+
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *InternalPackageManagerSpecApplyConfiguration) WithArgs(values ...string) *InternalPackageManagerSpecApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
 	return b
 }
 

--- a/config/crd/bases/core.posit.team_sites.yaml
+++ b/config/crd/bases/core.posit.team_sites.yaml
@@ -203,6 +203,14 @@ spec:
                       - rVersion
                       type: object
                     type: array
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     properties:
                       administratorRoleMapping:
@@ -259,6 +267,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   databaseSettings:
                     properties:
                       instrumentationSchema:
@@ -941,6 +957,14 @@ spec:
                     description: AdditionalConfig allows appending arbitrary gcfg
                       config content to the generated config.
                     type: string
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     description: Auth configures OIDC authentication for Package Manager's
                       web UI
@@ -1012,6 +1036,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   domainPrefix:
                     default: packagemanager
                     type: string

--- a/dist/chart/templates/crd/core.posit.team_sites.yaml
+++ b/dist/chart/templates/crd/core.posit.team_sites.yaml
@@ -224,6 +224,14 @@ spec:
                       - rVersion
                       type: object
                     type: array
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     properties:
                       administratorRoleMapping:
@@ -280,6 +288,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   databaseSettings:
                     properties:
                       instrumentationSchema:
@@ -962,6 +978,14 @@ spec:
                     description: AdditionalConfig allows appending arbitrary gcfg
                       config content to the generated config.
                     type: string
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     description: Auth configures OIDC authentication for Package Manager's
                       web UI
@@ -1033,6 +1057,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   domainPrefix:
                     default: packagemanager
                     type: string

--- a/internal/controller/core/site_controller_connect.go
+++ b/internal/controller/core/site_controller_connect.go
@@ -140,6 +140,8 @@ func (r *SiteReconciler) reconcileConnect(
 			Image:                        site.Spec.Connect.Image,
 			SessionImage:                 site.Spec.Connect.SessionImage,
 			ImagePullPolicy:              site.Spec.Connect.ImagePullPolicy,
+			Command:                      site.Spec.Connect.Command,
+			Args:                         site.Spec.Connect.Args,
 			ImagePullSecrets:             site.Spec.ImagePullSecrets,
 			ChronicleAgentImage:          site.Spec.Chronicle.AgentImage,
 			AdditionalVolumes:            additionalVolumes,

--- a/internal/controller/core/site_controller_package_manager.go
+++ b/internal/controller/core/site_controller_package_manager.go
@@ -95,6 +95,8 @@ func (r *SiteReconciler) reconcilePackageManager(
 			IngressAnnotations:           site.Spec.IngressAnnotations,
 			Image:                        site.Spec.PackageManager.Image,
 			ImagePullPolicy:              site.Spec.PackageManager.ImagePullPolicy,
+			Command:                      site.Spec.PackageManager.Command,
+			Args:                         site.Spec.PackageManager.Args,
 			ImagePullSecrets:             site.Spec.ImagePullSecrets,
 			ChronicleAgentImage:          site.Spec.Chronicle.AgentImage,
 			NodeSelector:                 site.Spec.PackageManager.NodeSelector,

--- a/internal/controller/core/site_test.go
+++ b/internal/controller/core/site_test.go
@@ -1256,6 +1256,62 @@ func TestSiteReconciler_RegisterOnFirstLoginDefaultNil(t *testing.T) {
 	assert.Nil(t, testConnect.Spec.RegisterOnFirstLogin)
 }
 
+func TestSiteReconciler_ConnectCommandArgsPropagation(t *testing.T) {
+	siteName := "connect-command-args"
+	siteNamespace := "posit-team"
+	site := defaultSite(siteName)
+	site.Spec.Connect.Command = []string{"/usr/local/bin/startup.sh"}
+	site.Spec.Connect.Args = []string{"--foo"}
+
+	cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+	assert.Nil(t, err)
+
+	testConnect := getConnect(t, cli, siteNamespace, siteName)
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, testConnect.Spec.Command)
+	assert.Equal(t, []string{"--foo"}, testConnect.Spec.Args)
+}
+
+func TestSiteReconciler_ConnectCommandArgsDefaultNil(t *testing.T) {
+	siteName := "connect-command-args-default"
+	siteNamespace := "posit-team"
+	site := defaultSite(siteName)
+
+	cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+	assert.Nil(t, err)
+
+	testConnect := getConnect(t, cli, siteNamespace, siteName)
+	assert.Nil(t, testConnect.Spec.Command)
+	assert.Nil(t, testConnect.Spec.Args)
+}
+
+func TestSiteReconciler_PackageManagerCommandArgsPropagation(t *testing.T) {
+	siteName := "packagemanager-command-args"
+	siteNamespace := "posit-team"
+	site := defaultSite(siteName)
+	site.Spec.PackageManager.Command = []string{"/usr/local/bin/startup.sh"}
+	site.Spec.PackageManager.Args = []string{"--foo"}
+
+	cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+	assert.Nil(t, err)
+
+	testPackageManager := getPackageManager(t, cli, siteNamespace, siteName)
+	assert.Equal(t, []string{"/usr/local/bin/startup.sh"}, testPackageManager.Spec.Command)
+	assert.Equal(t, []string{"--foo"}, testPackageManager.Spec.Args)
+}
+
+func TestSiteReconciler_PackageManagerCommandArgsDefaultNil(t *testing.T) {
+	siteName := "packagemanager-command-args-default"
+	siteNamespace := "posit-team"
+	site := defaultSite(siteName)
+
+	cli, _, err := runFakeSiteReconciler(t, siteNamespace, siteName, site)
+	assert.Nil(t, err)
+
+	testPackageManager := getPackageManager(t, cli, siteNamespace, siteName)
+	assert.Nil(t, testPackageManager.Spec.Command)
+	assert.Nil(t, testPackageManager.Spec.Args)
+}
+
 func TestSiteReconciler_BaseDomainNotSet(t *testing.T) {
 	siteName := "base-domain-not-set"
 	siteNamespace := "posit-team"

--- a/internal/crdapply/bases/core.posit.team_sites.yaml
+++ b/internal/crdapply/bases/core.posit.team_sites.yaml
@@ -203,6 +203,14 @@ spec:
                       - rVersion
                       type: object
                     type: array
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     properties:
                       administratorRoleMapping:
@@ -259,6 +267,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   databaseSettings:
                     properties:
                       instrumentationSchema:
@@ -941,6 +957,14 @@ spec:
                     description: AdditionalConfig allows appending arbitrary gcfg
                       config content to the generated config.
                     type: string
+                  args:
+                    description: |-
+                      Args overrides the container's command arguments. If unset (along with Command),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   auth:
                     description: Auth configures OIDC authentication for Package Manager's
                       web UI
@@ -1012,6 +1036,14 @@ spec:
                       BaseDomain overrides site.Spec.Domain for this product's URL construction.
                       When set, the product URL will be: domainPrefix.baseDomain
                     type: string
+                  command:
+                    description: |-
+                      Command overrides the container's entrypoint command. If unset (along with Args),
+                      defaults to the historical "tini -- /usr/local/bin/startup.sh" wrapper for
+                      backwards compatibility with existing deployments.
+                    items:
+                      type: string
+                    type: array
                   domainPrefix:
                     default: packagemanager
                     type: string


### PR DESCRIPTION
# Description

#156 added optional `Command []string` / `Args []string` fields to `ConnectSpec` and `PackageManagerSpec` so the hardcoded tini-wrapper entrypoint (`tini -- /usr/local/bin/startup.sh`) can be overridden or dropped. It only touched the standalone `Connect`/`PackageManager` CRDs, though — the `Site` CR's embedded `InternalConnectSpec`/`InternalPackageManagerSpec` types (`api/core/v1beta1/site_types.go`) have no equivalent fields, so anything deployed via a `Site` (which is how most consumers, including Posit's own agave environment, actually run these products) has no way to set them.

This follows up #156 for the `Site` path: adds `Command`/`Args` to both `Internal*Spec` types and threads them through `SiteReconciler.reconcileConnect`/`reconcilePackageManager` into the child `Connect`/`PackageManager` CRs it manages, using the exact same field docs/semantics as #156 (unset on both falls back to the legacy tini wrapper via `resolveEntrypoint` — no default behavior change for existing `Site`s).

## Motivation

`posit-dev/images-connect`-built images (the daily/preview channel) don't ship `tini`, so any `Site` tracking that channel crash-loops on `exec: "tini": executable file not found in $PATH` with no way to work around it short of this fix.

## Code Flow

- `InternalConnectSpec.Command`/`.Args` and `InternalPackageManagerSpec.Command`/`.Args` added (`api/core/v1beta1/site_types.go`).
- `site_controller_connect.go` / `site_controller_package_manager.go`: pass `site.Spec.Connect.Command/Args` and `site.Spec.PackageManager.Command/Args` straight through to the child CR's spec, mirroring every other pass-through field in those functions.
- Regenerated: `zz_generated.deepcopy.go`, `client-go/applyconfiguration/...`, `config/crd/bases/core.posit.team_sites.yaml`, `dist/chart/templates/crd/core.posit.team_sites.yaml`, `internal/crdapply/bases/core.posit.team_sites.yaml` (via `make generate-all manifests copy-crds helm-generate`).

## Category of change

- [ ] Breaking change

Purely additive — nil `Command`/`Args` on a `Site`'s `connect`/`packageManager` spec continues to fall back to the legacy tini wrapper exactly as before.

## Checklist

- [x] I have run `just test` and all tests pass
- [x] I have reviewed my own diff and added inline comments on lines I want reviewers to focus on or that I am uncertain about

## Testing

Added 4 reconciler tests mirroring #156's pattern: `TestSiteReconciler_ConnectCommandArgsPropagation`/`DefaultNil` and `TestSiteReconciler_PackageManagerCommandArgsPropagation`/`DefaultNil`, covering both the explicit-override and default (nil, legacy-wrapper-preserving) cases for each product.